### PR TITLE
feat: CipherStash Go Encryption SDK v2 - full feature parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">
   <img alt="CipherStash Logo" loading="lazy" width="128" height="128" decoding="async" data-nimg="1"   style="color:transparent" src="https://cipherstash.com/assets/cs-github.png">
   </br>
-  Protect.go
+  CipherStash Go Encryption SDK
 </h1>
 <p align="center">
   Implement robust data security without sacrificing performance or usability
@@ -29,7 +29,7 @@
 > This is a work in progress.
 > The package is not yet available on pkg.go.dev.
 
-Protect.go is a Go module for encrypting and decrypting data. Encryption operations happen directly in your app, and the ciphertext is stored in your database. Every value you encrypt with Protect.go has a unique key, made possible by CipherStash [ZeroKMS](https://cipherstash.com/products/zerokms)'s blazing fast bulk key operations, and backed by a root key in [AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html). The encrypted data is structured as an [EQL](https://github.com/cipherstash/encrypt-query-language) JSON payload, and can be stored in any database that supports JSONB.
+The CipherStash Go Encryption SDK is a Go module for encrypting, decrypting, and searching encrypted data. Encryption operations happen directly in your app, and the ciphertext is stored in your database. Every value you encrypt has a unique key, made possible by CipherStash [ZeroKMS](https://cipherstash.com/products/zerokms)'s blazing fast bulk key operations, and backed by a root key in [AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html). The encrypted data is structured as a JSON payload and can be stored in any database that supports JSONB.
 
 > [!IMPORTANT]  
 > Searching, sorting, and filtering on encrypted data is currently only supported when storing encrypted data in PostgreSQL.
@@ -38,9 +38,12 @@ Protect.go is a Go module for encrypting and decrypting data. Encryption operati
 
 - [Features](#features)
 - [Prebuilt Libraries](#prebuilt-libraries)
-- [Installing Protect.go](#installing-protectgo)
+- [Installing](#installing)
 - [Getting started](#getting-started)
 - [Basic usage](#basic-usage)
+- [Query encryption](#query-encryption)
+- [Model interface](#model-interface)
+- [Multi-tenant keysets](#multi-tenant-keysets)
 - [Configuration](#configuration)
 - [Identity-aware encryption](#identity-aware-encryption)
 - [Supported data types](#supported-data-types)
@@ -55,17 +58,21 @@ For more specific documentation, refer to the [docs](./docs).
 
 ## Features
 
-Protect.go protects data using industry-standard AES encryption. Protect.go uses [ZeroKMS](https://cipherstash.com/products/zerokms) for bulk encryption and decryption operations. This enables every encrypted value, in every column, in every row in your database to have a unique key — without sacrificing performance.
+The CipherStash Go Encryption SDK protects data using industry-standard AES encryption with [ZeroKMS](https://cipherstash.com/products/zerokms) for bulk encryption and decryption operations. This enables every encrypted value, in every column, in every row in your database to have a unique key — without sacrificing performance.
 
 **Features:**
 
-- **Bulk encryption and decryption**: Protect.go uses [ZeroKMS](https://cipherstash.com/products/zerokms) for encrypting and decrypting thousands of records at once, while using a unique key for every value.
-- **Single item encryption and decryption**: Just looking for a way to encrypt and decrypt single values? Protect.go has you covered.
-- **Really fast**: ZeroKMS's performance makes using millions of unique keys feasible and performant for real-world applications built with Protect.go.
-- **Identity-aware encryption**: Lock down access to sensitive data by requiring a valid JWT to perform a decryption.
-- **Audit trail**: Every decryption event will be logged in ZeroKMS to help you prove compliance.
-- **Searchable encryption**: Protect.go supports searching encrypted data in PostgreSQL.
-- **Type safety**: Strong typing with Go structs and interfaces.
+- **Bulk encryption and decryption**: Encrypt and decrypt thousands of records at once using [ZeroKMS](https://cipherstash.com/products/zerokms), with a unique key for every value.
+- **Single item encryption and decryption**: Encrypt and decrypt individual values with a simple API.
+- **Query encryption**: Encrypt search terms to query encrypted columns without decrypting the data first.
+- **Model interface**: Encrypt and decrypt entire Go structs using struct tags — no manual field-by-field encryption.
+- **Multi-type support**: Encrypt strings, numbers, booleans, and JSON values.
+- **Multi-tenant keysets**: Isolate encryption keys per tenant for multi-tenant applications.
+- **Really fast**: ZeroKMS's performance makes using millions of unique keys feasible and performant.
+- **Identity-aware encryption**: Lock down access to sensitive data by requiring a valid JWT to decrypt.
+- **Audit trail**: Every decryption event is logged in ZeroKMS to help prove compliance.
+- **Searchable encryption**: Search encrypted data in PostgreSQL using equality, full-text, range, and JSON containment queries.
+- **Structured errors**: Error codes for programmatic error handling.
 
 **Use cases:**
 
@@ -75,7 +82,7 @@ Protect.go protects data using industry-standard AES encryption. Protect.go uses
 
 ## Prebuilt Libraries
 
-Protect.go uses prebuilt static libraries to provide native cryptographic functionality across different platforms. The core encryption and decryption operations are implemented in Rust and compiled into platform-specific static libraries that are embedded directly into the Go package.
+The SDK uses prebuilt static libraries to provide native cryptographic functionality across different platforms. The core encryption and decryption operations are implemented in Rust and compiled into platform-specific static libraries that are embedded directly into the Go package.
 
 ### What libraries are prebuilt
 
@@ -88,8 +95,6 @@ The following static libraries are prebuilt and included in the Go package:
 - **Linux ARM64 (musl)**: `libprotect_ffi_linux_arm64_musl.a`
 - **Linux x64 (musl)**: `libprotect_ffi_linux_x64_musl.a`
 
-These libraries contain the compiled Rust code from the `protect-ffi-c` crate, which provides C-compatible FFI bindings for the CipherStash client functionality.
-
 ### How the libraries work
 
 1. **Rust Implementation**: Core encryption logic is implemented in Rust in the `crates/protect-ffi-c` directory
@@ -98,9 +103,9 @@ These libraries contain the compiled Rust code from the `protect-ffi-c` crate, w
 4. **Static Linking**: The Go package uses CGO to statically link against the appropriate prebuilt library for your platform
 5. **Platform Selection**: The correct library is automatically selected at build time based on your OS and architecture
 
-This approach ensures that Protect.go can leverage high-performance Rust cryptographic implementations while providing a native Go API, without requiring users to install Rust or compile anything themselves.
+This approach ensures that the SDK can leverage high-performance Rust cryptographic implementations while providing a native Go API, without requiring users to install Rust or compile anything themselves.
 
-## Installing Protect.go
+## Installing
 
 ### Prerequisites
 
@@ -129,9 +134,9 @@ go get github.com/cipherstash/protectgo/pkg/protect
 ### Configuration
 
 > [!IMPORTANT]  
-> Make sure you have [installed the CipherStash CLI](#installing-protectgo) before following these steps.
+> Make sure you have [installed the CipherStash CLI](#installing) before following these steps.
 
-To set up all the configuration and credentials required for Protect.go:
+To set up all the configuration and credentials required:
 
 ```bash
 stash setup
@@ -141,8 +146,8 @@ If you haven't already signed up for a CipherStash account, this will prompt you
 
 At the end of `stash setup`, you will have two files in your project:
 
-- `cipherstash.toml` which contains the configuration for Protect.go
-- `cipherstash.secret.toml`: which contains the credentials for Protect.go
+- `cipherstash.toml` which contains the configuration
+- `cipherstash.secret.toml`: which contains the credentials
 
 > [!WARNING]  
 > Don't commit `cipherstash.secret.toml` to git; it contains sensitive credentials.  
@@ -152,10 +157,10 @@ At the end of `stash setup`, you will have two files in your project:
 
 The library respects the following environment variables:
 
-- `CIPHERSTASH_WORKSPACE_CRN` - Workspace CRN
-- `CIPHERSTASH_ACCESS_KEY` - Access key
-- `CIPHERSTASH_CLIENT_ID` - Client ID  
-- `CIPHERSTASH_CLIENT_KEY` - Client key
+- `CS_WORKSPACE_CRN` - Workspace CRN
+- `CS_CLIENT_ACCESS_KEY` - Access key
+- `CS_CLIENT_ID` - Client ID  
+- `CS_CLIENT_KEY` - Client key
 
 ## Basic usage
 
@@ -165,20 +170,20 @@ The library respects the following environment variables:
 package main
 
 import (
-    "context"
     "log"
-    
+
     "github.com/cipherstash/protectgo/pkg/protect"
 )
 
 func main() {
     // Configure encryption settings
+    castAs := protect.CastAsString
     config := protect.EncryptConfig{
         Version: 1,
         Tables: protect.Tables{
             "users": protect.Table{
                 "email": protect.Column{
-                    CastAs: &protect.CastAsText,
+                    CastAs: &castAs,
                     Indexes: &protect.Indexes{
                         UniqueIndex: &protect.UniqueIndexOpts{
                             TokenFilters: []protect.TokenFilter{
@@ -210,17 +215,17 @@ func main() {
         log.Fatal(err)
     }
 
-    log.Printf("Encrypted: %s", *encrypted.Ciphertext)
+    log.Printf("Encrypted successfully")
 
     // Decrypt data
     plaintext, err := client.Decrypt(protect.DecryptOptions{
-        Ciphertext: *encrypted.Ciphertext,
+        Ciphertext: encrypted,
     })
     if err != nil {
         log.Fatal(err)
     }
 
-    log.Printf("Decrypted: %s", plaintext)
+    log.Printf("Decrypted: %v", plaintext)
 }
 ```
 
@@ -236,7 +241,7 @@ bulkEncrypted, err := client.EncryptBulk(protect.EncryptBulkOptions{
             Column:    "email",
         },
         {
-            Plaintext: "bob@example.com", 
+            Plaintext: "bob@example.com",
             Table:     "users",
             Column:    "email",
         },
@@ -248,9 +253,9 @@ if err != nil {
 
 // Bulk decryption
 ciphertexts := make([]protect.BulkDecryptPayload, len(bulkEncrypted))
-for i, enc := range bulkEncrypted {
+for i := range bulkEncrypted {
     ciphertexts[i] = protect.BulkDecryptPayload{
-        Ciphertext: *enc.Ciphertext,
+        Ciphertext: &bulkEncrypted[i],
     }
 }
 
@@ -264,22 +269,146 @@ if err != nil {
 log.Printf("Decrypted values: %v", plaintexts)
 ```
 
+## Query encryption
+
+Encrypt search terms to query encrypted columns without exposing plaintext in your queries.
+
+```go
+// Encrypt a query term for exact match
+queryEncrypted, err := client.EncryptQuery(protect.EncryptQueryOptions{
+    Plaintext: "john.doe@example.com",
+    Table:     "users",
+    Column:    "email",
+    IndexType: protect.IndexTypeUnique,
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+// Use queryEncrypted.UniqueIndex in your SQL WHERE clause
+
+// Encrypt a query term for full-text search
+searchEncrypted, err := client.EncryptQuery(protect.EncryptQueryOptions{
+    Plaintext: "john",
+    Table:     "users",
+    Column:    "name",
+    IndexType: protect.IndexTypeMatch,
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+// Batch encrypt multiple query terms
+batchEncrypted, err := client.EncryptQueryBulk(protect.EncryptQueryBulkOptions{
+    Queries: []protect.QueryPayload{
+        {
+            Plaintext: "alice@example.com",
+            Table:     "users",
+            Column:    "email",
+            IndexType: protect.IndexTypeUnique,
+        },
+        {
+            Plaintext: "bob",
+            Table:     "users",
+            Column:    "name",
+            IndexType: protect.IndexTypeMatch,
+        },
+    },
+})
+```
+
+### Query types
+
+| Index Type | Use Case | QueryOp |
+|---|---|---|
+| `IndexTypeUnique` | Exact match (`=`) | `QueryOpDefault` |
+| `IndexTypeMatch` | Full-text search (`LIKE`, `ILIKE`) | `QueryOpDefault` |
+| `IndexTypeOre` | Range comparisons (`<`, `>`, `<=`, `>=`) | `QueryOpDefault` |
+| `IndexTypeSteVec` | JSON path queries | `QueryOpSteVecSelector` |
+| `IndexTypeSteVec` | JSON containment (`@>`) | `QueryOpSteVecTerm` |
+
+## Model interface
+
+Encrypt and decrypt entire Go structs using the `cs` struct tag. Fields tagged with `cs:"column_name"` are automatically encrypted/decrypted. Non-tagged fields pass through unchanged.
+
+```go
+type User struct {
+    ID    int    `json:"id"`
+    Email string `json:"email" cs:"email"`
+    Name  string `json:"name"  cs:"name"`
+    Role  string `json:"role"`  // not encrypted
+}
+
+// Encrypt a model
+user := User{ID: 1, Email: "john@example.com", Name: "John", Role: "admin"}
+encrypted, err := client.EncryptModel(user, "users")
+// encrypted["id"] = 1
+// encrypted["email"] = *Encrypted{...}
+// encrypted["name"] = *Encrypted{...}
+// encrypted["role"] = "admin"
+
+// Decrypt back to a struct
+var decrypted User
+err = client.DecryptModel(encrypted, "users", &decrypted)
+// decrypted.Email == "john@example.com"
+// decrypted.Role == "admin"
+
+// Bulk encrypt models (single KMS call for all fields across all models)
+users := []User{
+    {ID: 1, Email: "alice@example.com", Name: "Alice", Role: "admin"},
+    {ID: 2, Email: "bob@example.com", Name: "Bob", Role: "user"},
+}
+encryptedModels, err := client.BulkEncryptModels(users, "users")
+
+// Bulk decrypt models
+var decryptedUsers []User
+err = client.BulkDecryptModels(encryptedModels, "users", &decryptedUsers)
+```
+
+## Multi-tenant keysets
+
+Isolate encryption keys per tenant by specifying a keyset when creating the client:
+
+```go
+client, err := protect.NewClient(protect.NewClientOptions{
+    EncryptConfig: config,
+    ClientOpts: &protect.ClientOpts{
+        Keyset: &protect.KeysetConfig{
+            Name: stringPtr("tenant-a"),
+        },
+    },
+})
+```
+
+Each keyset provides cryptographic isolation — data encrypted with one keyset cannot be decrypted with another.
+
 ## Configuration
 
 ### Encryption Configuration
 
 ```go
-type EncryptConfig struct {
-    Version uint32 `json:"v"`
-    Tables  Tables `json:"tables"`
-}
-
-type Tables map[string]Table
-type Table map[string]Column
-
-type Column struct {
-    CastAs  *CastAs  `json:"cast_as,omitempty"`
-    Indexes *Indexes `json:"indexes,omitempty"`
+config := protect.EncryptConfig{
+    Version: 1,
+    Tables: protect.Tables{
+        "users": protect.Table{
+            "email": protect.Column{
+                CastAs: &protect.CastAsString,
+                Indexes: &protect.Indexes{
+                    UniqueIndex: &protect.UniqueIndexOpts{},
+                    MatchIndex:  &protect.MatchIndexOpts{},
+                    OreIndex:    &protect.OreIndexOpts{},
+                },
+            },
+            "profile": protect.Column{
+                CastAs: &protect.CastAsJson,
+                Indexes: &protect.Indexes{
+                    SteVecIndex: &protect.SteVecIndexOpts{
+                        Prefix: "users/profile",
+                    },
+                },
+            },
+        },
+    },
 }
 ```
 
@@ -287,39 +416,41 @@ type Column struct {
 
 ```go
 type ClientOpts struct {
-    WorkspaceCrn *string `json:"workspaceCrn,omitempty"`
-    AccessKey    *string `json:"accessKey,omitempty"`
-    ClientID     *string `json:"clientId,omitempty"`
-    ClientKey    *string `json:"clientKey,omitempty"`
+    WorkspaceCrn *string       `json:"workspaceCrn,omitempty"`
+    AccessKey    *string       `json:"accessKey,omitempty"`
+    ClientID     *string       `json:"clientId,omitempty"`
+    ClientKey    *string       `json:"clientKey,omitempty"`
+    Keyset       *KeysetConfig `json:"keyset,omitempty"`
 }
 ```
 
 ### Index Types
 
-The library supports all the same index types as other Protect libraries:
-
-- **ORE Index**: For range queries and ordering
-- **Match Index**: For full-text search  
-- **Unique Index**: For exact matching and uniqueness constraints
-- **SteVec Index**: For vector similarity searches
+- **ORE Index**: For range queries and ordering (`<`, `>`, `<=`, `>=`)
+- **Match Index**: For full-text search with configurable tokenizers
+- **Unique Index**: For exact matching with optional case-insensitive filters
+- **SteVec Index**: For JSON path queries and containment searches
 
 ### Data Types
 
-Supported cast types:
-- `CastAsText` - UTF-8 strings
-- `CastAsInt` - 32-bit integers
-- `CastAsBigInt` - 64-bit integers
-- `CastAsBoolean` - Boolean values
-- `CastAsDate` - Date values
-- `CastAsReal/CastAsDouble` - Floating point numbers
-- `CastAsJsonB` - JSON data
+Supported `CastAs` types:
+
+| Go Constant | Description |
+|---|---|
+| `CastAsString` | UTF-8 strings (default) |
+| `CastAsText` | UTF-8 strings (alias) |
+| `CastAsBigInt` | 64-bit integers |
+| `CastAsNumber` | Floating point numbers |
+| `CastAsBoolean` | Boolean values |
+| `CastAsDate` | Date values |
+| `CastAsJson` | JSON data (required for SteVec index) |
 
 ## Identity-aware encryption
 
 > [!IMPORTANT]  
 > Identity-aware encryption requires implementing JWT validation in your application.
 
-Protect.go can add an additional layer of protection to your data by requiring a valid JWT to perform a decryption. This ensures that only the user who encrypted data is able to decrypt it.
+Lock down access to sensitive data by requiring a valid identity claim to decrypt. This ensures that only the user who encrypted data is able to decrypt it.
 
 ### Using Lock Context
 
@@ -339,7 +470,7 @@ encrypted, err := client.Encrypt(protect.EncryptOptions{
 
 // Decrypt with the same lock context
 plaintext, err := client.Decrypt(protect.DecryptOptions{
-    Ciphertext:  *encrypted.Ciphertext,
+    Ciphertext:  encrypted,
     LockContext: &lockContext,
 })
 ```
@@ -350,7 +481,12 @@ plaintext, err := client.Decrypt(protect.DecryptOptions{
 
 ## Supported data types
 
-Protect.go currently supports encrypting and decrypting text. Other data types like booleans, dates, ints, floats, and JSON are well-supported in other CipherStash products, and will be coming to Protect.go soon.
+The SDK supports encrypting and decrypting multiple data types:
+
+- **Strings** — text values
+- **Numbers** — floating point values (coerced to integer types based on `CastAs`)
+- **Booleans** — true/false values
+- **JSON** — objects and arrays (required for SteVec searchable encryption)
 
 ## Searchable encryption
 
@@ -384,23 +520,45 @@ Read more about [searching encrypted data](./docs/concepts/searchable-encryption
 
 ### Client Methods
 
-- `NewClient(options NewClientOptions) (*Client, error)` - Create a new client
-- `client.Free()` - Release client resources
-- `client.Encrypt(options EncryptOptions) (*Encrypted, error)` - Encrypt single value
-- `client.EncryptBulk(options EncryptBulkOptions) ([]Encrypted, error)` - Encrypt multiple values
-- `client.Decrypt(options DecryptOptions) (string, error)` - Decrypt single value  
-- `client.DecryptBulk(options DecryptBulkOptions) ([]string, error)` - Decrypt multiple values
-- `client.DecryptBulkFallible(options DecryptBulkOptions) ([]DecryptResult, error)` - Decrypt with error handling per item
+| Method | Description |
+|---|---|
+| `NewClient(options) (*Client, error)` | Create a new encryption client |
+| `client.Free()` | Release client resources |
+| `client.Encrypt(options) (*Encrypted, error)` | Encrypt a single value |
+| `client.EncryptBulk(options) ([]Encrypted, error)` | Encrypt multiple values |
+| `client.Decrypt(options) (interface{}, error)` | Decrypt a single value |
+| `client.DecryptBulk(options) ([]interface{}, error)` | Decrypt multiple values |
+| `client.DecryptBulkFallible(options) ([]DecryptResult, error)` | Decrypt with per-item error handling |
+| `client.EncryptQuery(options) (*Encrypted, error)` | Encrypt a search term |
+| `client.EncryptQueryBulk(options) ([]Encrypted, error)` | Encrypt multiple search terms |
+| `client.EncryptModel(model, table) (map[string]interface{}, error)` | Encrypt a struct |
+| `client.DecryptModel(data, table, dest) error` | Decrypt to a struct |
+| `client.BulkEncryptModels(models, table) ([]map[string]interface{}, error)` | Encrypt multiple structs |
+| `client.BulkDecryptModels(data, table, dest) error` | Decrypt to multiple structs |
+
+### Standalone Functions
+
+| Function | Description |
+|---|---|
+| `IsEncrypted(value) bool` | Check if a value is a valid encrypted payload |
 
 ### Error Handling
 
-All operations return Go-style errors. Use standard Go error handling patterns:
+All operations return structured errors with error codes for programmatic handling:
 
 ```go
+encrypted, err := client.Encrypt(opts)
 if err != nil {
-    // Handle error
-    log.Printf("Encryption failed: %v", err)
-    return err
+    if encErr, ok := err.(*protect.EncryptionError); ok {
+        switch encErr.Code {
+        case protect.ErrUnknownColumn:
+            log.Printf("Column not found in schema: %s", encErr.Message)
+        case protect.ErrMissingIndex:
+            log.Printf("Index not configured: %s", encErr.Message)
+        default:
+            log.Printf("Encryption error [%s]: %s", encErr.Code, encErr.Message)
+        }
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,82 +37,41 @@ The CipherStash Go Encryption SDK is a Go module for encrypting, decrypting, and
 ## Table of contents
 
 - [Features](#features)
-- [Prebuilt Libraries](#prebuilt-libraries)
 - [Installing](#installing)
 - [Getting started](#getting-started)
-- [Basic usage](#basic-usage)
+- [Defining your schema](#defining-your-schema)
+- [Encrypting and decrypting models](#encrypting-and-decrypting-models)
 - [Query encryption](#query-encryption)
-- [Model interface](#model-interface)
-- [Multi-tenant keysets](#multi-tenant-keysets)
-- [Configuration](#configuration)
+- [Single value operations](#single-value-operations)
+- [Bulk operations](#bulk-operations)
 - [Identity-aware encryption](#identity-aware-encryption)
-- [Supported data types](#supported-data-types)
-- [Searchable encryption](#searchable-encryption)
-- [API Reference](#api-reference)
-- [Building from source](#building-from-source)
-- [Example applications](#example-applications)
-- [Contributing](#contributing)
-- [License](#license)
-
-For more specific documentation, refer to the [docs](./docs).
+- [Multi-tenant keysets](#multi-tenant-keysets)
+- [Error handling](#error-handling)
+- [API reference](#api-reference)
+- [Searchable encryption with PostgreSQL](#searchable-encryption-with-postgresql)
+- [Prebuilt libraries](#prebuilt-libraries)
+- [Running the examples](#running-the-examples)
 
 ## Features
 
-The CipherStash Go Encryption SDK protects data using industry-standard AES encryption with [ZeroKMS](https://cipherstash.com/products/zerokms) for bulk encryption and decryption operations. This enables every encrypted value, in every column, in every row in your database to have a unique key — without sacrificing performance.
-
-**Features:**
-
-- **Bulk encryption and decryption**: Encrypt and decrypt thousands of records at once using [ZeroKMS](https://cipherstash.com/products/zerokms), with a unique key for every value.
-- **Single item encryption and decryption**: Encrypt and decrypt individual values with a simple API.
-- **Query encryption**: Encrypt search terms to query encrypted columns without decrypting the data first.
-- **Model interface**: Encrypt and decrypt entire Go structs using struct tags — no manual field-by-field encryption.
+- **Schema from struct tags**: Define your encryption schema directly on your Go structs using the `cs` struct tag. No manual configuration maps needed.
+- **Model encryption**: Encrypt and decrypt entire structs in one call. Non-encrypted fields pass through unchanged.
+- **Query encryption**: Encrypt search terms to query encrypted columns in PostgreSQL without decrypting the data first.
 - **Multi-type support**: Encrypt strings, numbers, booleans, and JSON values.
-- **Multi-tenant keysets**: Isolate encryption keys per tenant for multi-tenant applications.
-- **Really fast**: ZeroKMS's performance makes using millions of unique keys feasible and performant.
-- **Identity-aware encryption**: Lock down access to sensitive data by requiring a valid JWT to decrypt.
-- **Audit trail**: Every decryption event is logged in ZeroKMS to help prove compliance.
-- **Searchable encryption**: Search encrypted data in PostgreSQL using equality, full-text, range, and JSON containment queries.
-- **Structured errors**: Error codes for programmatic error handling.
-
-**Use cases:**
-
-- **Trusted data access**: make sure only your end-users can access their sensitive data stored in your product.
-- **Meet compliance requirements faster**: meet and exceed the data encryption requirements of SOC2 and ISO27001.
-- **Reduce the blast radius of data breaches**: limit the impact of exploited vulnerabilities to only the data your end-users can decrypt.
-
-## Prebuilt Libraries
-
-The SDK uses prebuilt static libraries to provide native cryptographic functionality across different platforms. The core encryption and decryption operations are implemented in Rust and compiled into platform-specific static libraries that are embedded directly into the Go package.
-
-### What libraries are prebuilt
-
-The following static libraries are prebuilt and included in the Go package:
-
-- **macOS ARM64**: `libprotect_ffi_darwin_arm64.a`
-- **macOS Intel**: `libprotect_ffi_darwin_x64.a`  
-- **Linux ARM64**: `libprotect_ffi_linux_arm64.a`
-- **Linux x64**: `libprotect_ffi_linux_x64.a`
-- **Linux ARM64 (musl)**: `libprotect_ffi_linux_arm64_musl.a`
-- **Linux x64 (musl)**: `libprotect_ffi_linux_x64_musl.a`
-
-### How the libraries work
-
-1. **Rust Implementation**: Core encryption logic is implemented in Rust in the `crates/protect-ffi-c` directory
-2. **C FFI Layer**: The Rust code exports C-compatible functions using FFI (Foreign Function Interface)
-3. **Header Generation**: C headers are automatically generated using `cbindgen` during the build process
-4. **Static Linking**: The Go package uses CGO to statically link against the appropriate prebuilt library for your platform
-5. **Platform Selection**: The correct library is automatically selected at build time based on your OS and architecture
-
-This approach ensures that the SDK can leverage high-performance Rust cryptographic implementations while providing a native Go API, without requiring users to install Rust or compile anything themselves.
+- **Bulk operations**: Encrypt and decrypt thousands of records at once with a single KMS call per operation.
+- **Identity-aware encryption**: Require a valid JWT identity claim to decrypt data.
+- **Multi-tenant keysets**: Isolate encryption keys per tenant.
+- **Searchable encryption**: Exact match, full-text search, range queries, and JSON containment on encrypted data.
+- **Really fast**: [ZeroKMS](https://cipherstash.com/products/zerokms) makes millions of unique keys feasible and performant.
 
 ## Installing
 
 ### Prerequisites
 
 - Go 1.21 or later
-- CipherStash CLI (for configuration)
+- A [CipherStash](https://cipherstash.com) account
 
-### Install the Go package
+### Install the package
 
 ```bash
 go get github.com/cipherstash/protectgo/pkg/protect
@@ -120,83 +79,64 @@ go get github.com/cipherstash/protectgo/pkg/protect
 
 ### Install the CipherStash CLI
 
-- On macOS:
-  ```bash
-  brew install cipherstash/tap/stash
-  ```
+```bash
+# macOS
+brew install cipherstash/tap/stash
 
-- On Linux, download the binary for your platform, and put it on your `PATH`:
-  - [Linux ARM64](https://github.com/cipherstash/cli-releases/releases/latest/download/stash-aarch64-unknown-linux-gnu)
-  - [Linux x86_64](https://github.com/cipherstash/cli-releases/releases/latest/download/stash-x86_64-unknown-linux-gnu)
+# Linux — download the binary for your platform
+# ARM64: https://github.com/cipherstash/cli-releases/releases/latest/download/stash-aarch64-unknown-linux-gnu
+# x86_64: https://github.com/cipherstash/cli-releases/releases/latest/download/stash-x86_64-unknown-linux-gnu
+```
 
 ## Getting started
 
-### Configuration
-
-> [!IMPORTANT]  
-> Make sure you have [installed the CipherStash CLI](#installing) before following these steps.
-
-To set up all the configuration and credentials required:
+### 1. Set up credentials
 
 ```bash
 stash setup
 ```
 
-If you haven't already signed up for a CipherStash account, this will prompt you to do so along the way.
-
-At the end of `stash setup`, you will have two files in your project:
-
-- `cipherstash.toml` which contains the configuration
-- `cipherstash.secret.toml`: which contains the credentials
+This creates `cipherstash.toml` (configuration) and `cipherstash.secret.toml` (credentials) in your project directory.
 
 > [!WARNING]  
-> Don't commit `cipherstash.secret.toml` to git; it contains sensitive credentials.  
-> The `stash setup` command will attempt to append to your `.gitignore` file with the `cipherstash.secret.toml` file.
+> Don't commit `cipherstash.secret.toml` to git — it contains sensitive credentials.
 
-### Environment Variables
+You can also use environment variables:
 
-The library respects the following environment variables:
+| Variable | Description |
+|---|---|
+| `CS_WORKSPACE_CRN` | Workspace CRN |
+| `CS_CLIENT_ACCESS_KEY` | Access key |
+| `CS_CLIENT_ID` | Client ID |
+| `CS_CLIENT_KEY` | Client key |
 
-- `CS_WORKSPACE_CRN` - Workspace CRN
-- `CS_CLIENT_ACCESS_KEY` - Access key
-- `CS_CLIENT_ID` - Client ID  
-- `CS_CLIENT_KEY` - Client key
-
-## Basic usage
-
-### Simple encryption and decryption
+### 2. Define your schema and create a client
 
 ```go
 package main
 
 import (
     "log"
-
     "github.com/cipherstash/protectgo/pkg/protect"
 )
 
-func main() {
-    // Configure encryption settings
-    castAs := protect.CastAsString
-    config := protect.EncryptConfig{
-        Version: 1,
-        Tables: protect.Tables{
-            "users": protect.Table{
-                "email": protect.Column{
-                    CastAs: &castAs,
-                    Indexes: &protect.Indexes{
-                        UniqueIndex: &protect.UniqueIndexOpts{
-                            TokenFilters: []protect.TokenFilter{
-                                {Kind: "downcase"},
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    }
+// Define your model with encryption using struct tags.
+// Fields with a `cs` tag are encrypted. Fields without it pass through unchanged.
+type User struct {
+    ID    int    `json:"id"`
+    Email string `json:"email" cs:"email,unique(downcase),match"`
+    Name  string `json:"name"  cs:"name,match"`
+    Age   int    `json:"age"   cs:"age,cast=number,ore"`
+    Role  string `json:"role"` // not encrypted
+}
 
-    // Create client
+func main() {
+    // Build encryption config from your struct
+    config := protect.BuildEncryptConfig(
+        protect.TableSchema("users", User{}),
+    )
+
+    // Create the client
     client, err := protect.NewClient(protect.NewClientOptions{
         EncryptConfig: config,
     })
@@ -205,165 +145,306 @@ func main() {
     }
     defer client.Free()
 
-    // Encrypt data
-    encrypted, err := client.Encrypt(protect.EncryptOptions{
-        Plaintext: "john.doe@example.com",
-        Table:     "users",
-        Column:    "email",
-    })
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    log.Printf("Encrypted successfully")
-
-    // Decrypt data
-    plaintext, err := client.Decrypt(protect.DecryptOptions{
-        Ciphertext: encrypted,
-    })
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    log.Printf("Decrypted: %v", plaintext)
+    // You're ready to encrypt!
 }
 ```
 
-### Bulk operations
+## Defining your schema
+
+The `cs` struct tag defines the encryption schema for each field. The format is:
+
+```
+cs:"<column_name>,<directives...>"
+```
+
+### Index directives
+
+| Directive | Description | Use case |
+|---|---|---|
+| `unique` | Exact match index | Equality queries (`WHERE email = ?`) |
+| `unique(downcase)` | Case-insensitive exact match | Case-insensitive lookups |
+| `match` | Full-text search index | Substring and fuzzy search (`LIKE`, `ILIKE`) |
+| `match(tokenizer=standard)` | Full-text with standard tokenizer | Word-boundary search |
+| `match(k=8,m=4096)` | Full-text with custom parameters | Tuning precision/recall |
+| `ore` | Order-revealing encryption index | Range queries (`<`, `>`, `BETWEEN`, `ORDER BY`) |
+| `ste_vec(prefix=table/col)` | JSON containment/path index | JSON path and `@>` queries |
+
+### Cast type override
+
+By default, the Go field type determines the encryption cast type:
+
+| Go type | Inferred cast |
+|---|---|
+| `string` | `string` |
+| `int`, `int64`, `float64`, etc. | `number` |
+| `bool` | `boolean` |
+| `map`, `struct`, `interface{}`, `[]T` | `json` |
+
+Override with `cast=<type>`:
 
 ```go
-// Bulk encryption
-bulkEncrypted, err := client.EncryptBulk(protect.EncryptBulkOptions{
-    Plaintexts: []protect.PlaintextPayload{
-        {
-            Plaintext: "alice@example.com",
-            Table:     "users",
-            Column:    "email",
-        },
-        {
-            Plaintext: "bob@example.com",
-            Table:     "users",
-            Column:    "email",
-        },
-    },
-})
-if err != nil {
-    log.Fatal(err)
+Age int `json:"age" cs:"age,cast=number,ore"`
+```
+
+Available cast types: `string`, `text`, `number`, `bigint`, `boolean`, `date`, `json`
+
+### Full example
+
+```go
+type User struct {
+    // Not encrypted — no `cs` tag
+    ID        int    `json:"id"`
+    Role      string `json:"role"`
+
+    // Encrypted with exact match + full-text search
+    Email     string `json:"email"   cs:"email,unique(downcase),match"`
+
+    // Encrypted with full-text search only
+    Name      string `json:"name"    cs:"name,match"`
+
+    // Encrypted with range queries (explicit number cast for int field)
+    Age       int    `json:"age"     cs:"age,cast=number,ore"`
+
+    // Encrypted, no search indexes
+    Active    bool   `json:"active"  cs:"active,cast=boolean"`
+
+    // Encrypted JSON with path and containment queries
+    Metadata  any    `json:"metadata" cs:"metadata,ste_vec(prefix=users/metadata)"`
+}
+```
+
+### Multiple tables
+
+```go
+config := protect.BuildEncryptConfig(
+    protect.TableSchema("users", User{}),
+    protect.TableSchema("orders", Order{}),
+    protect.TableSchema("products", Product{}),
+)
+```
+
+## Encrypting and decrypting models
+
+The model interface encrypts and decrypts entire Go structs. Fields with a `cs` tag are encrypted; all other fields pass through unchanged.
+
+### Encrypt a model
+
+```go
+user := User{
+    ID:    1,
+    Email: "alice@example.com",
+    Name:  "Alice Smith",
+    Age:   30,
+    Role:  "admin",
 }
 
-// Bulk decryption
+// Returns a map with encrypted fields as *Encrypted values
+// and plain fields as their original values
+encrypted, err := client.EncryptModel(user, "users")
+// encrypted["id"]    = 1         (plain)
+// encrypted["role"]  = "admin"   (plain)
+// encrypted["email"] = *Encrypted{...}
+// encrypted["name"]  = *Encrypted{...}
+// encrypted["age"]   = *Encrypted{...}
+```
+
+### Decrypt a model
+
+```go
+var decrypted User
+err = client.DecryptModel(encrypted, "users", &decrypted)
+// decrypted.Email == "alice@example.com"
+// decrypted.Name  == "Alice Smith"
+// decrypted.Age   == 30
+// decrypted.Role  == "admin"
+```
+
+### Bulk model operations
+
+Bulk operations collect all encrypted field values across all models and make a single KMS call, which is much faster than encrypting models one at a time.
+
+```go
+users := []User{
+    {ID: 1, Email: "alice@example.com", Name: "Alice", Age: 28, Role: "admin"},
+    {ID: 2, Email: "bob@example.com", Name: "Bob", Age: 35, Role: "user"},
+}
+
+// Single KMS call for all fields across all models
+encryptedModels, err := client.BulkEncryptModels(users, "users")
+
+// Decrypt back to structs
+var decryptedUsers []User
+err = client.BulkDecryptModels(encryptedModels, "users", &decryptedUsers)
+```
+
+## Query encryption
+
+Encrypt search terms to query encrypted columns without exposing plaintext in your queries. Use the encrypted index values in your SQL `WHERE` clauses.
+
+### Exact match
+
+```go
+query, err := client.EncryptQuery(protect.EncryptQueryOptions{
+    Plaintext: "alice@example.com",
+    Table:     "users",
+    Column:    "email",
+    IndexType: protect.IndexTypeUnique,
+})
+// Use query.UniqueIndex in: WHERE email_encrypted->>'hm' = ?
+```
+
+### Full-text search
+
+```go
+query, err := client.EncryptQuery(protect.EncryptQueryOptions{
+    Plaintext: "alice",
+    Table:     "users",
+    Column:    "name",
+    IndexType: protect.IndexTypeMatch,
+})
+// Use query.MatchIndex for full-text matching
+```
+
+### Range query
+
+```go
+query, err := client.EncryptQuery(protect.EncryptQueryOptions{
+    Plaintext: 25,
+    Table:     "users",
+    Column:    "age",
+    IndexType: protect.IndexTypeOre,
+})
+// Use query.OreIndex for: WHERE age_encrypted > ?
+```
+
+### JSON containment
+
+```go
+// Path query — find records that have a specific JSON path
+query, err := client.EncryptQuery(protect.EncryptQueryOptions{
+    Plaintext: "$.user.email",
+    Table:     "users",
+    Column:    "metadata",
+    IndexType: protect.IndexTypeSteVec,
+    QueryOp:   protect.QueryOpSteVecSelector,
+})
+
+// Containment query — find records matching a JSON fragment
+query, err := client.EncryptQuery(protect.EncryptQueryOptions{
+    Plaintext: map[string]interface{}{"role": "admin"},
+    Table:     "users",
+    Column:    "metadata",
+    IndexType: protect.IndexTypeSteVec,
+    QueryOp:   protect.QueryOpSteVecTerm,
+})
+```
+
+### Bulk query encryption
+
+```go
+queries, err := client.EncryptQueryBulk(protect.EncryptQueryBulkOptions{
+    Queries: []protect.QueryPayload{
+        {Plaintext: "alice@example.com", Table: "users", Column: "email", IndexType: protect.IndexTypeUnique},
+        {Plaintext: "bob", Table: "users", Column: "name", IndexType: protect.IndexTypeMatch},
+    },
+})
+```
+
+## Single value operations
+
+For fine-grained control, encrypt and decrypt individual values directly.
+
+### Encrypt
+
+```go
+encrypted, err := client.Encrypt(protect.EncryptOptions{
+    Plaintext: "alice@example.com",  // string, number, bool, or JSON
+    Table:     "users",
+    Column:    "email",
+})
+```
+
+### Decrypt
+
+```go
+plaintext, err := client.Decrypt(protect.DecryptOptions{
+    Ciphertext: encrypted,
+})
+// plaintext is interface{} — the original value type is preserved
+```
+
+### Validate encrypted data
+
+```go
+protect.IsEncrypted(encrypted)       // true
+protect.IsEncrypted("plain string")  // false
+```
+
+## Bulk operations
+
+Bulk operations use a single KMS call for all values, making them much faster than individual operations.
+
+```go
+// Encrypt
+bulkEncrypted, err := client.EncryptBulk(protect.EncryptBulkOptions{
+    Plaintexts: []protect.PlaintextPayload{
+        {Plaintext: "alice@example.com", Table: "users", Column: "email"},
+        {Plaintext: "bob@example.com", Table: "users", Column: "email"},
+    },
+})
+
+// Decrypt
 ciphertexts := make([]protect.BulkDecryptPayload, len(bulkEncrypted))
 for i := range bulkEncrypted {
-    ciphertexts[i] = protect.BulkDecryptPayload{
-        Ciphertext: &bulkEncrypted[i],
-    }
+    ciphertexts[i] = protect.BulkDecryptPayload{Ciphertext: &bulkEncrypted[i]}
 }
 
 plaintexts, err := client.DecryptBulk(protect.DecryptBulkOptions{
     Ciphertexts: ciphertexts,
 })
-if err != nil {
-    log.Fatal(err)
-}
 
-log.Printf("Decrypted values: %v", plaintexts)
+// Fallible decrypt — per-item error handling instead of all-or-nothing
+results, err := client.DecryptBulkFallible(protect.DecryptBulkOptions{
+    Ciphertexts: ciphertexts,
+})
+for _, r := range results {
+    if r.Error != nil {
+        fmt.Printf("Failed: %s\n", *r.Error)
+    } else {
+        fmt.Printf("Value: %v\n", r.Data)
+    }
+}
 ```
 
-## Query encryption
+## Identity-aware encryption
 
-Encrypt search terms to query encrypted columns without exposing plaintext in your queries.
+Lock down access to sensitive data by requiring a valid identity claim to decrypt. Data encrypted with a lock context can only be decrypted with the same context.
 
 ```go
-// Encrypt a query term for exact match
-queryEncrypted, err := client.EncryptQuery(protect.EncryptQueryOptions{
-    Plaintext: "john.doe@example.com",
-    Table:     "users",
-    Column:    "email",
-    IndexType: protect.IndexTypeUnique,
-})
-if err != nil {
-    log.Fatal(err)
+lockContext := &protect.LockContext{
+    IdentityClaim: []string{"user:12345"}, // Extract from JWT
 }
 
-// Use queryEncrypted.UniqueIndex in your SQL WHERE clause
-
-// Encrypt a query term for full-text search
-searchEncrypted, err := client.EncryptQuery(protect.EncryptQueryOptions{
-    Plaintext: "john",
-    Table:     "users",
-    Column:    "name",
-    IndexType: protect.IndexTypeMatch,
+// Encrypt with lock context
+encrypted, err := client.Encrypt(protect.EncryptOptions{
+    Plaintext:   "sensitive-data",
+    Table:       "users",
+    Column:      "email",
+    LockContext: lockContext,
 })
-if err != nil {
-    log.Fatal(err)
-}
 
-// Batch encrypt multiple query terms
-batchEncrypted, err := client.EncryptQueryBulk(protect.EncryptQueryBulkOptions{
-    Queries: []protect.QueryPayload{
-        {
-            Plaintext: "alice@example.com",
-            Table:     "users",
-            Column:    "email",
-            IndexType: protect.IndexTypeUnique,
-        },
-        {
-            Plaintext: "bob",
-            Table:     "users",
-            Column:    "name",
-            IndexType: protect.IndexTypeMatch,
-        },
-    },
+// Must use the same lock context to decrypt
+plaintext, err := client.Decrypt(protect.DecryptOptions{
+    Ciphertext:  encrypted,
+    LockContext: lockContext,
 })
 ```
 
-### Query types
+> [!CAUTION]  
+> You must use the same lock context to encrypt and decrypt data.  
+> If you use different lock contexts, you will be unable to decrypt the data.
 
-| Index Type | Use Case | QueryOp |
-|---|---|---|
-| `IndexTypeUnique` | Exact match (`=`) | `QueryOpDefault` |
-| `IndexTypeMatch` | Full-text search (`LIKE`, `ILIKE`) | `QueryOpDefault` |
-| `IndexTypeOre` | Range comparisons (`<`, `>`, `<=`, `>=`) | `QueryOpDefault` |
-| `IndexTypeSteVec` | JSON path queries | `QueryOpSteVecSelector` |
-| `IndexTypeSteVec` | JSON containment (`@>`) | `QueryOpSteVecTerm` |
-
-## Model interface
-
-Encrypt and decrypt entire Go structs using the `cs` struct tag. Fields tagged with `cs:"column_name"` are automatically encrypted/decrypted. Non-tagged fields pass through unchanged.
-
-```go
-type User struct {
-    ID    int    `json:"id"`
-    Email string `json:"email" cs:"email"`
-    Name  string `json:"name"  cs:"name"`
-    Role  string `json:"role"`  // not encrypted
-}
-
-// Encrypt a model
-user := User{ID: 1, Email: "john@example.com", Name: "John", Role: "admin"}
-encrypted, err := client.EncryptModel(user, "users")
-// encrypted["id"] = 1
-// encrypted["email"] = *Encrypted{...}
-// encrypted["name"] = *Encrypted{...}
-// encrypted["role"] = "admin"
-
-// Decrypt back to a struct
-var decrypted User
-err = client.DecryptModel(encrypted, "users", &decrypted)
-// decrypted.Email == "john@example.com"
-// decrypted.Role == "admin"
-
-// Bulk encrypt models (single KMS call for all fields across all models)
-users := []User{
-    {ID: 1, Email: "alice@example.com", Name: "Alice", Role: "admin"},
-    {ID: 2, Email: "bob@example.com", Name: "Bob", Role: "user"},
-}
-encryptedModels, err := client.BulkEncryptModels(users, "users")
-
-// Bulk decrypt models
-var decryptedUsers []User
-err = client.BulkDecryptModels(encryptedModels, "users", &decryptedUsers)
-```
+Lock context also works with model operations and bulk operations.
 
 ## Multi-tenant keysets
 
@@ -374,7 +455,7 @@ client, err := protect.NewClient(protect.NewClientOptions{
     EncryptConfig: config,
     ClientOpts: &protect.ClientOpts{
         Keyset: &protect.KeysetConfig{
-            Name: stringPtr("tenant-a"),
+            Name: ptr("tenant-a"),
         },
     },
 })
@@ -382,167 +463,7 @@ client, err := protect.NewClient(protect.NewClientOptions{
 
 Each keyset provides cryptographic isolation — data encrypted with one keyset cannot be decrypted with another.
 
-## Configuration
-
-### Encryption Configuration
-
-```go
-config := protect.EncryptConfig{
-    Version: 1,
-    Tables: protect.Tables{
-        "users": protect.Table{
-            "email": protect.Column{
-                CastAs: &protect.CastAsString,
-                Indexes: &protect.Indexes{
-                    UniqueIndex: &protect.UniqueIndexOpts{},
-                    MatchIndex:  &protect.MatchIndexOpts{},
-                    OreIndex:    &protect.OreIndexOpts{},
-                },
-            },
-            "profile": protect.Column{
-                CastAs: &protect.CastAsJson,
-                Indexes: &protect.Indexes{
-                    SteVecIndex: &protect.SteVecIndexOpts{
-                        Prefix: "users/profile",
-                    },
-                },
-            },
-        },
-    },
-}
-```
-
-### Client Configuration
-
-```go
-type ClientOpts struct {
-    WorkspaceCrn *string       `json:"workspaceCrn,omitempty"`
-    AccessKey    *string       `json:"accessKey,omitempty"`
-    ClientID     *string       `json:"clientId,omitempty"`
-    ClientKey    *string       `json:"clientKey,omitempty"`
-    Keyset       *KeysetConfig `json:"keyset,omitempty"`
-}
-```
-
-### Index Types
-
-- **ORE Index**: For range queries and ordering (`<`, `>`, `<=`, `>=`)
-- **Match Index**: For full-text search with configurable tokenizers
-- **Unique Index**: For exact matching with optional case-insensitive filters
-- **SteVec Index**: For JSON path queries and containment searches
-
-### Data Types
-
-Supported `CastAs` types:
-
-| Go Constant | Description |
-|---|---|
-| `CastAsString` | UTF-8 strings (default) |
-| `CastAsText` | UTF-8 strings (alias) |
-| `CastAsBigInt` | 64-bit integers |
-| `CastAsNumber` | Floating point numbers |
-| `CastAsBoolean` | Boolean values |
-| `CastAsDate` | Date values |
-| `CastAsJson` | JSON data (required for SteVec index) |
-
-## Identity-aware encryption
-
-> [!IMPORTANT]  
-> Identity-aware encryption requires implementing JWT validation in your application.
-
-Lock down access to sensitive data by requiring a valid identity claim to decrypt. This ensures that only the user who encrypted data is able to decrypt it.
-
-### Using Lock Context
-
-```go
-// Create lock context from JWT claims
-lockContext := protect.LockContext{
-    IdentityClaim: []string{"user:12345"}, // Extract from JWT
-}
-
-// Encrypt with lock context
-encrypted, err := client.Encrypt(protect.EncryptOptions{
-    Plaintext:   "sensitive-data",
-    Table:       "users",
-    Column:      "email",
-    LockContext: &lockContext,
-})
-
-// Decrypt with the same lock context
-plaintext, err := client.Decrypt(protect.DecryptOptions{
-    Ciphertext:  encrypted,
-    LockContext: &lockContext,
-})
-```
-
-> [!CAUTION]  
-> You must use the same lock context to encrypt and decrypt data.  
-> If you use different lock contexts, you will be unable to decrypt the data.
-
-## Supported data types
-
-The SDK supports encrypting and decrypting multiple data types:
-
-- **Strings** — text values
-- **Numbers** — floating point values (coerced to integer types based on `CastAs`)
-- **Booleans** — true/false values
-- **JSON** — objects and arrays (required for SteVec searchable encryption)
-
-## Searchable encryption
-
-> [!IMPORTANT]  
-> Searchable encryption requires PostgreSQL with EQL extensions installed.
-
-To enable searchable encryption, you need to install EQL in your PostgreSQL database:
-
-1. Download the latest EQL install script:
-   ```bash
-   curl -sLo cipherstash-encrypt.sql \
-     https://github.com/cipherstash/encrypt-query-language/releases/latest/download/cipherstash-encrypt.sql
-   ```
-
-2. Run this command to install the custom types and functions:
-   ```bash
-   psql -f cipherstash-encrypt.sql
-   ```
-
-3. Create tables with the `eql_v2_encrypted` type:
-   ```sql
-   CREATE TABLE users (
-       id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-       email eql_v2_encrypted
-   );
-   ```
-
-Read more about [searching encrypted data](./docs/concepts/searchable-encryption.md) in the docs.
-
-## API Reference
-
-### Client Methods
-
-| Method | Description |
-|---|---|
-| `NewClient(options) (*Client, error)` | Create a new encryption client |
-| `client.Free()` | Release client resources |
-| `client.Encrypt(options) (*Encrypted, error)` | Encrypt a single value |
-| `client.EncryptBulk(options) ([]Encrypted, error)` | Encrypt multiple values |
-| `client.Decrypt(options) (interface{}, error)` | Decrypt a single value |
-| `client.DecryptBulk(options) ([]interface{}, error)` | Decrypt multiple values |
-| `client.DecryptBulkFallible(options) ([]DecryptResult, error)` | Decrypt with per-item error handling |
-| `client.EncryptQuery(options) (*Encrypted, error)` | Encrypt a search term |
-| `client.EncryptQueryBulk(options) ([]Encrypted, error)` | Encrypt multiple search terms |
-| `client.EncryptModel(model, table) (map[string]interface{}, error)` | Encrypt a struct |
-| `client.DecryptModel(data, table, dest) error` | Decrypt to a struct |
-| `client.BulkEncryptModels(models, table) ([]map[string]interface{}, error)` | Encrypt multiple structs |
-| `client.BulkDecryptModels(data, table, dest) error` | Decrypt to multiple structs |
-
-### Standalone Functions
-
-| Function | Description |
-|---|---|
-| `IsEncrypted(value) bool` | Check if a value is a valid encrypted payload |
-
-### Error Handling
+## Error handling
 
 All operations return structured errors with error codes for programmatic handling:
 
@@ -552,46 +473,128 @@ if err != nil {
     if encErr, ok := err.(*protect.EncryptionError); ok {
         switch encErr.Code {
         case protect.ErrUnknownColumn:
-            log.Printf("Column not found in schema: %s", encErr.Message)
+            log.Printf("Column not in schema: %s", encErr.Message)
         case protect.ErrMissingIndex:
             log.Printf("Index not configured: %s", encErr.Message)
+        case protect.ErrInvalidQueryInput:
+            log.Printf("Bad query input: %s", encErr.Message)
         default:
-            log.Printf("Encryption error [%s]: %s", encErr.Code, encErr.Message)
+            log.Printf("Error [%s]: %s", encErr.Code, encErr.Message)
         }
     }
 }
 ```
 
-## Running the basic usage example
+| Error Code | Description |
+|---|---|
+| `ErrUnknownColumn` | Column not found in encryption schema |
+| `ErrMissingIndex` | Required index not configured on column |
+| `ErrInvalidQueryInput` | Wrong value type for query operation |
+| `ErrInvalidJsonPath` | Invalid JSON path for SteVec selector |
+| `ErrSteVecRequiresJsonCastAs` | SteVec index requires `cast=json` |
+| `ErrUnknownQueryOp` | Unrecognized query operation |
+| `ErrInvariantViolation` | Internal SDK bug |
 
-### Running with glibc (default)
+## API reference
 
-For most Linux distributions that use glibc:
+### Schema
+
+| Function | Description |
+|---|---|
+| `TableSchema(name, model) *TableDef` | Build a table schema from a struct's `cs` tags |
+| `BuildEncryptConfig(tables...) EncryptConfig` | Assemble table schemas into an encryption config |
+
+### Client
+
+| Method | Description |
+|---|---|
+| `NewClient(options) (*Client, error)` | Create an encryption client |
+| `client.Free()` | Release client resources |
+
+### Encryption
+
+| Method | Description |
+|---|---|
+| `client.Encrypt(opts) (*Encrypted, error)` | Encrypt a single value |
+| `client.EncryptBulk(opts) ([]Encrypted, error)` | Encrypt multiple values |
+| `client.Decrypt(opts) (interface{}, error)` | Decrypt a single value |
+| `client.DecryptBulk(opts) ([]interface{}, error)` | Decrypt multiple values |
+| `client.DecryptBulkFallible(opts) ([]DecryptResult, error)` | Decrypt with per-item error handling |
+
+### Models
+
+| Method | Description |
+|---|---|
+| `client.EncryptModel(model, table) (map[string]interface{}, error)` | Encrypt a struct |
+| `client.DecryptModel(data, table, &dest) error` | Decrypt to a struct |
+| `client.BulkEncryptModels(models, table) ([]map[string]interface{}, error)` | Encrypt a slice of structs |
+| `client.BulkDecryptModels(data, table, &dest) error` | Decrypt to a slice of structs |
+
+### Query encryption
+
+| Method | Description |
+|---|---|
+| `client.EncryptQuery(opts) (*Encrypted, error)` | Encrypt a search term |
+| `client.EncryptQueryBulk(opts) ([]Encrypted, error)` | Encrypt multiple search terms |
+
+### Utilities
+
+| Function | Description |
+|---|---|
+| `IsEncrypted(value) bool` | Check if a value is a valid encrypted payload |
+
+## Searchable encryption with PostgreSQL
+
+> [!IMPORTANT]  
+> Searchable encryption requires PostgreSQL with EQL extensions installed.
+
+1. Install EQL in your database:
+
+   ```bash
+   curl -sLo cipherstash-encrypt.sql \
+     https://github.com/cipherstash/encrypt-query-language/releases/latest/download/cipherstash-encrypt.sql
+   psql -f cipherstash-encrypt.sql
+   ```
+
+2. Create tables with the `eql_v2_encrypted` type:
+
+   ```sql
+   CREATE TABLE users (
+       id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+       email eql_v2_encrypted
+   );
+   ```
+
+Read more about [searching encrypted data](./docs/concepts/searchable-encryption.md) in the docs.
+
+## Prebuilt libraries
+
+The SDK ships with precompiled static libraries for all supported platforms. No Rust toolchain required.
+
+| Platform | Library |
+|---|---|
+| macOS ARM64 | `libprotect_ffi_darwin_arm64.a` |
+| macOS Intel | `libprotect_ffi_darwin_x64.a` |
+| Linux ARM64 | `libprotect_ffi_linux_arm64.a` |
+| Linux x64 | `libprotect_ffi_linux_x64.a` |
+| Linux ARM64 (musl) | `libprotect_ffi_linux_arm64_musl.a` |
+| Linux x64 (musl) | `libprotect_ffi_linux_x64_musl.a` |
+
+The correct library is selected automatically at build time based on your OS and architecture.
+
+## Running the examples
 
 ```bash
+# Default (glibc)
 go run examples/basic_usage.go
-```
 
-### Running with musl (Alpine Linux)
-
-For Alpine Linux or musl-based systems:
-
-```bash
+# Alpine Linux / musl
 go run -tags=musl examples/basic_usage.go
-```
 
-### Building a static binary with musl
-
-To create a completely static binary of the example:
-
-```bash
-# Build static Go binary
+# Static binary
 CGO_ENABLED=1 go build -ldflags '-linkmode external -extldflags "-static"' -tags=musl examples/basic_usage.go
-
-# Run the static binary
-./basic_usage_static
 ```
 
-### Didn't find what you wanted?
+---
 
-[Click here to let us know what was missing from our docs.](https://github.com/cipherstash/protectgo/issues/new?template=docs-feedback.yml&title=[Docs:]%20Feedback%20on%20README.md) 
+[Missing something from the docs?](https://github.com/cipherstash/protectgo/issues/new?template=docs-feedback.yml&title=[Docs:]%20Feedback%20on%20README.md)

--- a/README.md
+++ b/README.md
@@ -29,77 +29,79 @@
 > This is a work in progress.
 > The package is not yet available on pkg.go.dev.
 
-The CipherStash Go Encryption SDK is a Go module for encrypting, decrypting, and searching encrypted data. Encryption operations happen directly in your app, and the ciphertext is stored in your database. Every value you encrypt has a unique key, made possible by CipherStash [ZeroKMS](https://cipherstash.com/products/zerokms)'s blazing fast bulk key operations, and backed by a root key in [AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html). The encrypted data is structured as a JSON payload and can be stored in any database that supports JSONB.
+The CipherStash Go Encryption SDK encrypts, decrypts, and searches encrypted data. Every value you encrypt has a unique key, made possible by CipherStash [ZeroKMS](https://cipherstash.com/products/zerokms)'s bulk key operations, backed by a root key in [AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html). The encrypted data is stored as a JSON payload in any database that supports JSONB.
 
 > [!IMPORTANT]  
-> Searching, sorting, and filtering on encrypted data is currently only supported when storing encrypted data in PostgreSQL.
+> Searching, sorting, and filtering on encrypted data requires PostgreSQL.
 
-## Table of contents
+## Quick start
 
-- [Features](#features)
-- [Installing](#installing)
-- [Getting started](#getting-started)
-- [Defining your schema](#defining-your-schema)
-- [Encrypting and decrypting models](#encrypting-and-decrypting-models)
-- [Query encryption](#query-encryption)
-- [Single value operations](#single-value-operations)
-- [Bulk operations](#bulk-operations)
-- [Identity-aware encryption](#identity-aware-encryption)
-- [Multi-tenant keysets](#multi-tenant-keysets)
-- [Error handling](#error-handling)
-- [API reference](#api-reference)
-- [Searchable encryption with PostgreSQL](#searchable-encryption-with-postgresql)
-- [Prebuilt libraries](#prebuilt-libraries)
-- [Running the examples](#running-the-examples)
+```go
+package main
 
-## Features
+import (
+    "context"
+    "log"
 
-- **Schema from struct tags**: Define your encryption schema directly on your Go structs using the `cs` struct tag. No manual configuration maps needed.
-- **Model encryption**: Encrypt and decrypt entire structs in one call. Non-encrypted fields pass through unchanged.
-- **Query encryption**: Encrypt search terms to query encrypted columns in PostgreSQL without decrypting the data first.
-- **Multi-type support**: Encrypt strings, numbers, booleans, and JSON values.
-- **Bulk operations**: Encrypt and decrypt thousands of records at once with a single KMS call per operation.
-- **Identity-aware encryption**: Require a valid JWT identity claim to decrypt data.
-- **Multi-tenant keysets**: Isolate encryption keys per tenant.
-- **Searchable encryption**: Exact match, full-text search, range queries, and JSON containment on encrypted data.
-- **Really fast**: [ZeroKMS](https://cipherstash.com/products/zerokms) makes millions of unique keys feasible and performant.
+    "github.com/cipherstash/protectgo/pkg/protect"
+)
+
+// Define your model. The `cs` tag marks fields for encryption.
+type User struct {
+    ID    int    `json:"id"`
+    Email string `json:"email" cs:"email,unique(downcase),match"`
+    Name  string `json:"name"  cs:"name,match"`
+    Age   int    `json:"age"   cs:"age,cast=number,ore"`
+    Role  string `json:"role"`
+}
+
+func main() {
+    ctx := context.Background()
+
+    // Build schema from struct tags
+    users, _ := protect.TableSchema("users", User{})
+
+    // Create client — credentials from env vars or config files
+    client, err := protect.NewClient(ctx, protect.WithSchemas(users))
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer client.Close()
+
+    // Encrypt a model
+    user := User{ID: 1, Email: "john@example.com", Name: "John", Age: 30, Role: "admin"}
+    encrypted, err := client.EncryptModel(ctx, users, user)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Decrypt back to struct
+    var decrypted User
+    client.DecryptModel(ctx, users, encrypted, &decrypted)
+    log.Printf("%s <%s>", decrypted.Name, decrypted.Email)
+}
+```
 
 ## Installing
-
-### Prerequisites
-
-- Go 1.21 or later
-- A [CipherStash](https://cipherstash.com) account
-
-### Install the package
 
 ```bash
 go get github.com/cipherstash/protectgo/pkg/protect
 ```
 
-### Install the CipherStash CLI
+### CipherStash CLI
 
 ```bash
 # macOS
 brew install cipherstash/tap/stash
 
-# Linux — download the binary for your platform
-# ARM64: https://github.com/cipherstash/cli-releases/releases/latest/download/stash-aarch64-unknown-linux-gnu
-# x86_64: https://github.com/cipherstash/cli-releases/releases/latest/download/stash-x86_64-unknown-linux-gnu
-```
-
-## Getting started
-
-### 1. Set up credentials
-
-```bash
+# Then set up credentials
 stash setup
 ```
 
-This creates `cipherstash.toml` (configuration) and `cipherstash.secret.toml` (credentials) in your project directory.
+This creates `cipherstash.toml` and `cipherstash.secret.toml` in your project.
 
 > [!WARNING]  
-> Don't commit `cipherstash.secret.toml` to git — it contains sensitive credentials.
+> Don't commit `cipherstash.secret.toml` to git.
 
 You can also use environment variables:
 
@@ -110,462 +112,285 @@ You can also use environment variables:
 | `CS_CLIENT_ID` | Client ID |
 | `CS_CLIENT_KEY` | Client key |
 
-### 2. Define your schema and create a client
-
-```go
-package main
-
-import (
-    "log"
-    "github.com/cipherstash/protectgo/pkg/protect"
-)
-
-// Define your model with encryption using struct tags.
-// Fields with a `cs` tag are encrypted. Fields without it pass through unchanged.
-type User struct {
-    ID    int    `json:"id"`
-    Email string `json:"email" cs:"email,unique(downcase),match"`
-    Name  string `json:"name"  cs:"name,match"`
-    Age   int    `json:"age"   cs:"age,cast=number,ore"`
-    Role  string `json:"role"` // not encrypted
-}
-
-func main() {
-    // Build encryption config from your struct
-    config := protect.BuildEncryptConfig(
-        protect.TableSchema("users", User{}),
-    )
-
-    // Create the client
-    client, err := protect.NewClient(protect.NewClientOptions{
-        EncryptConfig: config,
-    })
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer client.Free()
-
-    // You're ready to encrypt!
-}
-```
-
 ## Defining your schema
 
-The `cs` struct tag defines the encryption schema for each field. The format is:
+### Struct tags
 
-```
-cs:"<column_name>,<directives...>"
-```
-
-### Index directives
-
-| Directive | Description | Use case |
-|---|---|---|
-| `unique` | Exact match index | Equality queries (`WHERE email = ?`) |
-| `unique(downcase)` | Case-insensitive exact match | Case-insensitive lookups |
-| `match` | Full-text search index | Substring and fuzzy search (`LIKE`, `ILIKE`) |
-| `match(tokenizer=standard)` | Full-text with standard tokenizer | Word-boundary search |
-| `match(k=8,m=4096)` | Full-text with custom parameters | Tuning precision/recall |
-| `ore` | Order-revealing encryption index | Range queries (`<`, `>`, `BETWEEN`, `ORDER BY`) |
-| `ste_vec(prefix=table/col)` | JSON containment/path index | JSON path and `@>` queries |
-
-### Cast type override
-
-By default, the Go field type determines the encryption cast type:
-
-| Go type | Inferred cast |
-|---|---|
-| `string` | `string` |
-| `int`, `int64`, `float64`, etc. | `number` |
-| `bool` | `boolean` |
-| `map`, `struct`, `interface{}`, `[]T` | `json` |
-
-Override with `cast=<type>`:
-
-```go
-Age int `json:"age" cs:"age,cast=number,ore"`
-```
-
-Available cast types: `string`, `text`, `number`, `bigint`, `boolean`, `date`, `json`
-
-### Full example
+The `cs` tag defines the encryption schema directly on your Go structs:
 
 ```go
 type User struct {
-    // Not encrypted — no `cs` tag
-    ID        int    `json:"id"`
-    Role      string `json:"role"`
-
-    // Encrypted with exact match + full-text search
-    Email     string `json:"email"   cs:"email,unique(downcase),match"`
-
-    // Encrypted with full-text search only
-    Name      string `json:"name"    cs:"name,match"`
-
-    // Encrypted with range queries (explicit number cast for int field)
-    Age       int    `json:"age"     cs:"age,cast=number,ore"`
-
-    // Encrypted, no search indexes
-    Active    bool   `json:"active"  cs:"active,cast=boolean"`
-
-    // Encrypted JSON with path and containment queries
-    Metadata  any    `json:"metadata" cs:"metadata,ste_vec(prefix=users/metadata)"`
+    ID       int    `json:"id"`                                          // not encrypted
+    Email    string `json:"email" cs:"email,unique(downcase),match"`     // exact match + full-text
+    Name     string `json:"name"  cs:"name,match"`                      // full-text search
+    Age      int    `json:"age"   cs:"age,cast=number,ore"`             // range queries
+    Metadata any    `json:"metadata" cs:"metadata,ste_vec(prefix=u/m)"` // JSON queries
+    Role     string `json:"role"`                                        // not encrypted
 }
+
+users, err := protect.TableSchema("users", User{})
+```
+
+#### Index directives
+
+| Directive | Description |
+|---|---|
+| `unique` | Exact match queries (`WHERE email = ?`) |
+| `unique(downcase)` | Case-insensitive exact match |
+| `match` | Full-text search (ngram tokenizer, k=6, m=2048) |
+| `match(tokenizer=standard)` | Full-text with word-boundary tokenizer |
+| `ore` | Range queries (`<`, `>`, `BETWEEN`, `ORDER BY`) |
+| `ste_vec(prefix=t/c)` | JSON path and containment queries |
+
+#### Type inference
+
+Cast type is inferred from the Go field type. Override with `cast=<type>`:
+
+| Go type | Inferred cast | Override example |
+|---|---|---|
+| `string` | `string` | `cast=text` |
+| `int`, `float64` | `number` | `cast=bigint` |
+| `bool` | `boolean` | |
+| `map`, `any`, `[]T` | `json` | |
+
+### Programmatic builder
+
+For complex schemas or when you prefer type safety over struct tags:
+
+```go
+users := protect.NewSchema("users").
+    Column("email", protect.CastAsString).Equality().FreeTextSearch().Done().
+    Column("name", protect.CastAsString).FreeTextSearch().Done().
+    Column("age", protect.CastAsNumber).OrderAndRange().Done().
+    Column("profile", protect.CastAsJson).SearchableJSON("users/profile").Done().
+    Build()
 ```
 
 ### Multiple tables
 
 ```go
-config := protect.BuildEncryptConfig(
-    protect.TableSchema("users", User{}),
-    protect.TableSchema("orders", Order{}),
-    protect.TableSchema("products", Product{}),
+client, err := protect.NewClient(ctx,
+    protect.WithSchemas(users, orders, products),
 )
 ```
 
-## Encrypting and decrypting models
-
-The model interface encrypts and decrypts entire Go structs. Fields with a `cs` tag are encrypted; all other fields pass through unchanged.
-
-### Encrypt a model
+## Creating a client
 
 ```go
-user := User{
-    ID:    1,
-    Email: "alice@example.com",
-    Name:  "Alice Smith",
-    Age:   30,
-    Role:  "admin",
-}
+// Minimal — credentials from env vars or config files
+client, err := protect.NewClient(ctx, protect.WithSchemas(users))
 
-// Returns a map with encrypted fields as *Encrypted values
-// and plain fields as their original values
-encrypted, err := client.EncryptModel(user, "users")
-// encrypted["id"]    = 1         (plain)
-// encrypted["role"]  = "admin"   (plain)
-// encrypted["email"] = *Encrypted{...}
-// encrypted["name"]  = *Encrypted{...}
-// encrypted["age"]   = *Encrypted{...}
+// Explicit credentials
+client, err := protect.NewClient(ctx,
+    protect.WithSchemas(users),
+    protect.WithCredentials(crn, accessKey, clientID, clientKey),
+)
+
+// Multi-tenant keyset isolation
+client, err := protect.NewClient(ctx,
+    protect.WithSchemas(users),
+    protect.WithKeyset("tenant-a"),
+)
+
+defer client.Close()
 ```
 
-### Decrypt a model
+## Encrypting and decrypting
+
+### Models
+
+The fastest way to encrypt data. Fields with a `cs` tag are encrypted; everything else passes through.
 
 ```go
+user := User{ID: 1, Email: "alice@example.com", Name: "Alice", Age: 28, Role: "admin"}
+
+// Encrypt — returns map with *Encrypted values for tagged fields
+encrypted, err := client.EncryptModel(ctx, users, user)
+
+// Decrypt — populates struct from encrypted map
 var decrypted User
-err = client.DecryptModel(encrypted, "users", &decrypted)
-// decrypted.Email == "alice@example.com"
-// decrypted.Name  == "Alice Smith"
-// decrypted.Age   == 30
-// decrypted.Role  == "admin"
+err = client.DecryptModel(ctx, users, encrypted, &decrypted)
 ```
 
-### Bulk model operations
+### Bulk models
 
-Bulk operations collect all encrypted field values across all models and make a single KMS call, which is much faster than encrypting models one at a time.
+Single KMS call for all fields across all models:
 
 ```go
-users := []User{
-    {ID: 1, Email: "alice@example.com", Name: "Alice", Age: 28, Role: "admin"},
-    {ID: 2, Email: "bob@example.com", Name: "Bob", Age: 35, Role: "user"},
-}
+encryptedModels, err := client.BulkEncryptModels(ctx, users, userSlice)
 
-// Single KMS call for all fields across all models
-encryptedModels, err := client.BulkEncryptModels(users, "users")
-
-// Decrypt back to structs
 var decryptedUsers []User
-err = client.BulkDecryptModels(encryptedModels, "users", &decryptedUsers)
+err = client.BulkDecryptModels(ctx, users, encryptedModels, &decryptedUsers)
 ```
 
-## Query encryption
+### Single values
 
-Encrypt search terms to query encrypted columns without exposing plaintext in your queries. Use the encrypted index values in your SQL `WHERE` clauses.
-
-### Exact match
+Column references come from the schema — no string arguments:
 
 ```go
-query, err := client.EncryptQuery(protect.EncryptQueryOptions{
-    Plaintext: "alice@example.com",
-    Table:     "users",
-    Column:    "email",
-    IndexType: protect.IndexTypeUnique,
-})
-// Use query.UniqueIndex in: WHERE email_encrypted->>'hm' = ?
+encrypted, err := client.Encrypt(ctx, users.Column("email"), "alice@example.com")
+plaintext, err := client.Decrypt(ctx, encrypted)
 ```
 
-### Full-text search
+### Bulk values
 
 ```go
-query, err := client.EncryptQuery(protect.EncryptQueryOptions{
-    Plaintext: "alice",
-    Table:     "users",
-    Column:    "name",
-    IndexType: protect.IndexTypeMatch,
-})
-// Use query.MatchIndex for full-text matching
-```
-
-### Range query
-
-```go
-query, err := client.EncryptQuery(protect.EncryptQueryOptions{
-    Plaintext: 25,
-    Table:     "users",
-    Column:    "age",
-    IndexType: protect.IndexTypeOre,
-})
-// Use query.OreIndex for: WHERE age_encrypted > ?
-```
-
-### JSON containment
-
-```go
-// Path query — find records that have a specific JSON path
-query, err := client.EncryptQuery(protect.EncryptQueryOptions{
-    Plaintext: "$.user.email",
-    Table:     "users",
-    Column:    "metadata",
-    IndexType: protect.IndexTypeSteVec,
-    QueryOp:   protect.QueryOpSteVecSelector,
-})
-
-// Containment query — find records matching a JSON fragment
-query, err := client.EncryptQuery(protect.EncryptQueryOptions{
-    Plaintext: map[string]interface{}{"role": "admin"},
-    Table:     "users",
-    Column:    "metadata",
-    IndexType: protect.IndexTypeSteVec,
-    QueryOp:   protect.QueryOpSteVecTerm,
-})
-```
-
-### Bulk query encryption
-
-```go
-queries, err := client.EncryptQueryBulk(protect.EncryptQueryBulkOptions{
-    Queries: []protect.QueryPayload{
-        {Plaintext: "alice@example.com", Table: "users", Column: "email", IndexType: protect.IndexTypeUnique},
-        {Plaintext: "bob", Table: "users", Column: "name", IndexType: protect.IndexTypeMatch},
-    },
-})
-```
-
-## Single value operations
-
-For fine-grained control, encrypt and decrypt individual values directly.
-
-### Encrypt
-
-```go
-encrypted, err := client.Encrypt(protect.EncryptOptions{
-    Plaintext: "alice@example.com",  // string, number, bool, or JSON
-    Table:     "users",
-    Column:    "email",
-})
-```
-
-### Decrypt
-
-```go
-plaintext, err := client.Decrypt(protect.DecryptOptions{
-    Ciphertext: encrypted,
-})
-// plaintext is interface{} — the original value type is preserved
-```
-
-### Validate encrypted data
-
-```go
-protect.IsEncrypted(encrypted)       // true
-protect.IsEncrypted("plain string")  // false
-```
-
-## Bulk operations
-
-Bulk operations use a single KMS call for all values, making them much faster than individual operations.
-
-```go
-// Encrypt
-bulkEncrypted, err := client.EncryptBulk(protect.EncryptBulkOptions{
-    Plaintexts: []protect.PlaintextPayload{
-        {Plaintext: "alice@example.com", Table: "users", Column: "email"},
-        {Plaintext: "bob@example.com", Table: "users", Column: "email"},
-    },
-})
-
-// Decrypt
-ciphertexts := make([]protect.BulkDecryptPayload, len(bulkEncrypted))
-for i := range bulkEncrypted {
-    ciphertexts[i] = protect.BulkDecryptPayload{Ciphertext: &bulkEncrypted[i]}
+items := []protect.PlaintextItem{
+    {Column: users.Column("email"), Plaintext: "alice@example.com"},
+    {Column: users.Column("email"), Plaintext: "bob@example.com"},
 }
-
-plaintexts, err := client.DecryptBulk(protect.DecryptBulkOptions{
-    Ciphertexts: ciphertexts,
-})
-
-// Fallible decrypt — per-item error handling instead of all-or-nothing
-results, err := client.DecryptBulkFallible(protect.DecryptBulkOptions{
-    Ciphertexts: ciphertexts,
-})
-for _, r := range results {
-    if r.Error != nil {
-        fmt.Printf("Failed: %s\n", *r.Error)
-    } else {
-        fmt.Printf("Value: %v\n", r.Data)
-    }
-}
+encrypted, err := client.EncryptBulk(ctx, items)
 ```
 
-## Identity-aware encryption
-
-Lock down access to sensitive data by requiring a valid identity claim to decrypt. Data encrypted with a lock context can only be decrypted with the same context.
+### With options
 
 ```go
-lockContext := &protect.LockContext{
-    IdentityClaim: []string{"user:12345"}, // Extract from JWT
-}
+lc := &protect.LockContext{IdentityClaim: []string{"user:123"}}
 
-// Encrypt with lock context
-encrypted, err := client.Encrypt(protect.EncryptOptions{
-    Plaintext:   "sensitive-data",
-    Table:       "users",
-    Column:      "email",
-    LockContext: lockContext,
-})
+encrypted, err := client.Encrypt(ctx, users.Column("email"), "alice@example.com",
+    protect.WithLockContext(lc),
+)
 
-// Must use the same lock context to decrypt
-plaintext, err := client.Decrypt(protect.DecryptOptions{
-    Ciphertext:  encrypted,
-    LockContext: lockContext,
-})
+plaintext, err := client.Decrypt(ctx, encrypted,
+    protect.WithLockContext(lc),
+)
 ```
 
 > [!CAUTION]  
-> You must use the same lock context to encrypt and decrypt data.  
-> If you use different lock contexts, you will be unable to decrypt the data.
+> Data encrypted with a lock context can only be decrypted with the same context.
 
-Lock context also works with model operations and bulk operations.
+## Querying encrypted data
 
-## Multi-tenant keysets
-
-Isolate encryption keys per tenant by specifying a keyset when creating the client:
+Encrypt search terms to query encrypted columns without exposing plaintext:
 
 ```go
-client, err := protect.NewClient(protect.NewClientOptions{
-    EncryptConfig: config,
-    ClientOpts: &protect.ClientOpts{
-        Keyset: &protect.KeysetConfig{
-            Name: ptr("tenant-a"),
-        },
-    },
+// Exact match
+query, _ := client.EncryptQuery(ctx, users.Column("email"), protect.Equality, "alice@example.com")
+// Use query.UniqueIndex in SQL
+
+// Full-text search
+query, _ := client.EncryptQuery(ctx, users.Column("name"), protect.FreeTextSearch, "alice")
+// Use query.MatchIndex in SQL
+
+// Range comparison
+query, _ := client.EncryptQuery(ctx, users.Column("age"), protect.OrderAndRange, 25)
+// Use query.OreIndex in SQL
+
+// JSON containment
+query, _ := client.EncryptQuery(ctx, users.Column("metadata"), protect.JSONContains, map[string]any{"role": "admin"})
+
+// Bulk queries
+queries, _ := client.EncryptQueryBulk(ctx, []protect.QueryItem{
+    {Column: users.Column("email"), QueryType: protect.Equality, Plaintext: "alice@example.com"},
+    {Column: users.Column("name"), QueryType: protect.FreeTextSearch, Plaintext: "bob"},
 })
 ```
 
-Each keyset provides cryptographic isolation — data encrypted with one keyset cannot be decrypted with another.
+| Query Type | Use Case |
+|---|---|
+| `protect.Equality` | Exact match (`=`) |
+| `protect.FreeTextSearch` | Substring/fuzzy search |
+| `protect.OrderAndRange` | Range comparisons, sorting |
+| `protect.JSONSelector` | JSON path queries (`$.field`) |
+| `protect.JSONContains` | JSON containment (`@>`) |
 
 ## Error handling
 
-All operations return structured errors with error codes for programmatic handling:
+All errors support `errors.Is()` for programmatic handling:
 
 ```go
-encrypted, err := client.Encrypt(opts)
-if err != nil {
-    if encErr, ok := err.(*protect.EncryptionError); ok {
-        switch encErr.Code {
-        case protect.ErrUnknownColumn:
-            log.Printf("Column not in schema: %s", encErr.Message)
-        case protect.ErrMissingIndex:
-            log.Printf("Index not configured: %s", encErr.Message)
-        case protect.ErrInvalidQueryInput:
-            log.Printf("Bad query input: %s", encErr.Message)
-        default:
-            log.Printf("Error [%s]: %s", encErr.Code, encErr.Message)
-        }
-    }
+_, err := client.Encrypt(ctx, users.Column("email"), "value")
+
+if errors.Is(err, protect.ErrUnknownColumn) {
+    // column not in schema
+}
+if errors.Is(err, protect.ErrMissingIndex) {
+    // index not configured for this query type
+}
+if errors.Is(err, protect.ErrClientClosed) {
+    // client was already closed
 }
 ```
 
-| Error Code | Description |
+| Sentinel | Description |
 |---|---|
 | `ErrUnknownColumn` | Column not found in encryption schema |
-| `ErrMissingIndex` | Required index not configured on column |
+| `ErrMissingIndex` | Required index not configured |
 | `ErrInvalidQueryInput` | Wrong value type for query operation |
-| `ErrInvalidJsonPath` | Invalid JSON path for SteVec selector |
-| `ErrSteVecRequiresJsonCastAs` | SteVec index requires `cast=json` |
-| `ErrUnknownQueryOp` | Unrecognized query operation |
-| `ErrInvariantViolation` | Internal SDK bug |
+| `ErrInvalidJSONPath` | Invalid JSON path for selector query |
+| `ErrClientClosed` | Client has been closed |
 
 ## API reference
 
 ### Schema
 
-| Function | Description |
-|---|---|
-| `TableSchema(name, model) *TableDef` | Build a table schema from a struct's `cs` tags |
-| `BuildEncryptConfig(tables...) EncryptConfig` | Assemble table schemas into an encryption config |
+```go
+func TableSchema(tableName string, model any) (*TableDef, error)
+func NewSchema(tableName string) *SchemaBuilder
+func (td *TableDef) Column(name string) ColumnRef
+func (td *TableDef) Name() string
+```
 
 ### Client
 
-| Method | Description |
-|---|---|
-| `NewClient(options) (*Client, error)` | Create an encryption client |
-| `client.Free()` | Release client resources |
+```go
+func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error)
+func (c *Client) Close() error
 
-### Encryption
+// Options
+func WithSchemas(schemas ...*TableDef) ClientOption
+func WithCredentials(workspaceCRN, accessKey, clientID, clientKey string) ClientOption
+func WithKeyset(name string) ClientOption
+```
 
-| Method | Description |
-|---|---|
-| `client.Encrypt(opts) (*Encrypted, error)` | Encrypt a single value |
-| `client.EncryptBulk(opts) ([]Encrypted, error)` | Encrypt multiple values |
-| `client.Decrypt(opts) (interface{}, error)` | Decrypt a single value |
-| `client.DecryptBulk(opts) ([]interface{}, error)` | Decrypt multiple values |
-| `client.DecryptBulkFallible(opts) ([]DecryptResult, error)` | Decrypt with per-item error handling |
+### Operations
+
+```go
+func (c *Client) Encrypt(ctx, col, plaintext, ...Option) (*Encrypted, error)
+func (c *Client) Decrypt(ctx, encrypted, ...Option) (any, error)
+func (c *Client) EncryptBulk(ctx, items, ...Option) ([]Encrypted, error)
+func (c *Client) DecryptBulk(ctx, items, ...Option) ([]any, error)
+func (c *Client) DecryptBulkFallible(ctx, items, ...Option) ([]DecryptResult, error)
+func (c *Client) EncryptQuery(ctx, col, queryType, plaintext, ...Option) (*Encrypted, error)
+func (c *Client) EncryptQueryBulk(ctx, queries, ...Option) ([]Encrypted, error)
+
+// Options
+func WithLockContext(lc *LockContext) Option
+func WithServiceToken(token string) Option
+func WithAuditContext(ctx any) Option
+```
 
 ### Models
 
-| Method | Description |
-|---|---|
-| `client.EncryptModel(model, table) (map[string]interface{}, error)` | Encrypt a struct |
-| `client.DecryptModel(data, table, &dest) error` | Decrypt to a struct |
-| `client.BulkEncryptModels(models, table) ([]map[string]interface{}, error)` | Encrypt a slice of structs |
-| `client.BulkDecryptModels(data, table, &dest) error` | Decrypt to a slice of structs |
-
-### Query encryption
-
-| Method | Description |
-|---|---|
-| `client.EncryptQuery(opts) (*Encrypted, error)` | Encrypt a search term |
-| `client.EncryptQueryBulk(opts) ([]Encrypted, error)` | Encrypt multiple search terms |
+```go
+func (c *Client) EncryptModel(ctx, schema, model) (map[string]any, error)
+func (c *Client) DecryptModel(ctx, schema, data, dest) error
+func (c *Client) BulkEncryptModels(ctx, schema, models) ([]map[string]any, error)
+func (c *Client) BulkDecryptModels(ctx, schema, data, dest) error
+```
 
 ### Utilities
 
-| Function | Description |
-|---|---|
-| `IsEncrypted(value) bool` | Check if a value is a valid encrypted payload |
+```go
+func IsEncrypted(value any) bool
+```
 
-## Searchable encryption with PostgreSQL
+## PostgreSQL setup
 
-> [!IMPORTANT]  
-> Searchable encryption requires PostgreSQL with EQL extensions installed.
+Searchable encryption requires the EQL extension:
 
-1. Install EQL in your database:
+```bash
+curl -sLo cipherstash-encrypt.sql \
+  https://github.com/cipherstash/encrypt-query-language/releases/latest/download/cipherstash-encrypt.sql
+psql -f cipherstash-encrypt.sql
+```
 
-   ```bash
-   curl -sLo cipherstash-encrypt.sql \
-     https://github.com/cipherstash/encrypt-query-language/releases/latest/download/cipherstash-encrypt.sql
-   psql -f cipherstash-encrypt.sql
-   ```
-
-2. Create tables with the `eql_v2_encrypted` type:
-
-   ```sql
-   CREATE TABLE users (
-       id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-       email eql_v2_encrypted
-   );
-   ```
-
-Read more about [searching encrypted data](./docs/concepts/searchable-encryption.md) in the docs.
+```sql
+CREATE TABLE users (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    email eql_v2_encrypted
+);
+```
 
 ## Prebuilt libraries
 
@@ -580,21 +405,15 @@ The SDK ships with precompiled static libraries for all supported platforms. No 
 | Linux ARM64 (musl) | `libprotect_ffi_linux_arm64_musl.a` |
 | Linux x64 (musl) | `libprotect_ffi_linux_x64_musl.a` |
 
-The correct library is selected automatically at build time based on your OS and architecture.
-
 ## Running the examples
 
 ```bash
-# Default (glibc)
 go run examples/basic_usage.go
 
 # Alpine Linux / musl
 go run -tags=musl examples/basic_usage.go
-
-# Static binary
-CGO_ENABLED=1 go build -ldflags '-linkmode external -extldflags "-static"' -tags=musl examples/basic_usage.go
 ```
 
 ---
 
-[Missing something from the docs?](https://github.com/cipherstash/protectgo/issues/new?template=docs-feedback.yml&title=[Docs:]%20Feedback%20on%20README.md)
+[Missing something?](https://github.com/cipherstash/protectgo/issues/new?template=docs-feedback.yml&title=[Docs:]%20Feedback%20on%20README.md)

--- a/crates/protect-ffi-c/Cargo.toml
+++ b/crates/protect-ffi-c/Cargo.toml
@@ -8,16 +8,18 @@ name = "protect_ffi"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-cipherstash-client = "0.24.0"
-cts-common = "0.3.0"
+cipherstash-client = { version = "=0.34.1-alpha.2", features = ["tokio"] }
+cipherstash-config = { version = "=0.34.1-alpha.2" }
+cipherstash-core = { version = "=0.34.1-alpha.2" }
+cts-common = { version = "=0.34.1-alpha.2", default-features = false }
+stack-profile = { version = "=0.34.1-alpha.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
-anyhow = "1.0"
-uuid = { version = "1.0", features = ["v4"] }
-once_cell = "1.19"
-thiserror = "1.0"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+thiserror = "2.0"
 hex = "0.4"
+once_cell = "1.20"
+rust_decimal = "1.37"
 
 [build-dependencies]
 cbindgen = "0.26"

--- a/crates/protect-ffi-c/src/encrypt_config.rs
+++ b/crates/protect-ffi-c/src/encrypt_config.rs
@@ -1,6 +1,6 @@
 use super::Error;
 use cipherstash_client::schema::{
-    column::{Index, IndexType, TokenFilter, Tokenizer},
+    column::{ArrayIndexMode, Index, IndexType, TokenFilter, Tokenizer},
     ColumnConfig, ColumnType,
 };
 use serde::{Deserialize, Serialize};
@@ -66,19 +66,16 @@ pub struct Column {
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "lowercase")]
 pub enum CastAs {
     BigInt,
     Boolean,
     Date,
-    Real,
-    Double,
-    Int,
-    SmallInt,
+    Number,
     #[default]
+    String,
     Text,
-    #[serde(rename = "jsonb")]
-    JsonB,
+    Json,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
@@ -113,6 +110,10 @@ pub struct MatchIndexOpts {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct SteVecIndexOpts {
     prefix: String,
+    #[serde(default)]
+    term_filters: Vec<TokenFilter>,
+    #[serde(default)]
+    array_index_mode: ArrayIndexMode,
 }
 
 fn default_tokenizer() -> Tokenizer {
@@ -137,13 +138,12 @@ impl From<CastAs> for ColumnType {
     fn from(value: CastAs) -> Self {
         match value {
             CastAs::BigInt => ColumnType::BigInt,
-            CastAs::SmallInt => ColumnType::SmallInt,
-            CastAs::Int => ColumnType::Int,
             CastAs::Boolean => ColumnType::Boolean,
             CastAs::Date => ColumnType::Date,
-            CastAs::Real | CastAs::Double => ColumnType::Float,
+            CastAs::Number => ColumnType::Float,
+            CastAs::String => ColumnType::Utf8Str,
             CastAs::Text => ColumnType::Utf8Str,
-            CastAs::JsonB => ColumnType::JsonB,
+            CastAs::Json => ColumnType::JsonB,
         }
     }
 }
@@ -158,22 +158,35 @@ impl FromStr for EncryptConfig {
 }
 
 impl EncryptConfig {
-    pub fn into_config_map(self) -> HashMap<Identifier, ColumnConfig> {
+    pub fn into_config_map(self) -> Result<HashMap<Identifier, ColumnConfig>, super::Error> {
         let mut map = HashMap::new();
         for (table_name, columns) in self.tables.into_iter() {
             for (column_name, column) in columns.into_iter() {
-                let column_config = column.into_column_config(&column_name);
+                let column_config = column.into_column_config(&table_name, &column_name)?;
                 let key = Identifier::new(&table_name, &column_name);
                 map.insert(key, column_config);
             }
         }
-        map
+        Ok(map)
     }
 }
 
 impl Column {
-    pub fn into_column_config(self, name: &String) -> ColumnConfig {
-        let mut config = ColumnConfig::build(name.to_string()).casts_as(self.cast_as.into());
+    pub fn into_column_config(
+        self,
+        table_name: &str,
+        column_name: &str,
+    ) -> Result<ColumnConfig, super::Error> {
+        // Validate ste_vec requires cast_as: json
+        if self.indexes.ste_vec_index.is_some() && self.cast_as != CastAs::Json {
+            return Err(super::Error::SteVecRequiresJsonCastAs {
+                table: table_name.to_string(),
+                column: column_name.to_string(),
+                found_cast_as: cast_as_name(&self.cast_as).to_string(),
+            });
+        }
+
+        let mut config = ColumnConfig::build(column_name.to_string()).casts_as(self.cast_as.into());
 
         if self.indexes.ore_index.is_some() {
             config = config.add_index(Index::new_ore());
@@ -195,11 +208,33 @@ impl Column {
             }))
         }
 
-        if let Some(SteVecIndexOpts { prefix }) = self.indexes.ste_vec_index {
-            config = config.add_index(Index::new(IndexType::SteVec { prefix }))
+        if let Some(SteVecIndexOpts {
+            prefix,
+            term_filters,
+            array_index_mode,
+        }) = self.indexes.ste_vec_index
+        {
+            config = config.add_index(Index::new(IndexType::SteVec {
+                prefix,
+                term_filters,
+                array_index_mode,
+            }))
         }
 
-        config
+        Ok(config)
+    }
+}
+
+/// Get a human-readable name for CastAs value
+fn cast_as_name(cast_as: &CastAs) -> &'static str {
+    match cast_as {
+        CastAs::BigInt => "bigint",
+        CastAs::Boolean => "boolean",
+        CastAs::Date => "date",
+        CastAs::Number => "number",
+        CastAs::String => "string",
+        CastAs::Text => "text",
+        CastAs::Json => "json",
     }
 }
 
@@ -211,7 +246,8 @@ mod tests {
 
     fn parse(json: serde_json::Value) -> HashMap<Identifier, ColumnConfig> {
         serde_json::from_value::<EncryptConfig>(json)
-            .map(|config| config.into_config_map())
+            .unwrap()
+            .into_config_map()
             .unwrap()
     }
 
@@ -243,7 +279,7 @@ mod tests {
             "tables": {
                 "users": {
                     "favourite_int": {
-                        "cast_as": "int"
+                        "cast_as": "number"
                     }
                 }
             }
@@ -255,7 +291,7 @@ mod tests {
 
         let column = encrypt_config.get(&ident).expect("column exists");
 
-        assert_eq!(column.cast_type, ColumnType::Int);
+        assert_eq!(column.cast_type, ColumnType::Float);
         assert_eq!(column.name, "favourite_int");
         assert!(column.indexes.is_empty());
     }
@@ -456,6 +492,7 @@ mod tests {
             "tables": {
                 "users": {
                     "event_data": {
+                        "cast_as": "json",
                         "indexes": {
                             "ste_vec": {
                                 "prefix": "event-data"
@@ -472,11 +509,89 @@ mod tests {
 
         let column = encrypt_config.get(&ident).expect("column exists");
 
+        assert_eq!(column.cast_type, ColumnType::JsonB);
         assert_eq!(
             column.indexes[0].index_type,
             IndexType::SteVec {
-                prefix: "event-data".into()
+                prefix: "event-data".into(),
+                term_filters: vec![],
+                array_index_mode: Default::default(),
             },
         );
+    }
+
+    #[test]
+    fn ste_vec_with_non_json_cast_as_fails_validation() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "users": {
+                    "event_data": {
+                        "cast_as": "string",
+                        "indexes": {
+                            "ste_vec": {
+                                "prefix": "event-data"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let result = serde_json::from_value::<EncryptConfig>(json)
+            .unwrap()
+            .into_config_map();
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("users"),
+            "Error should mention table name: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("event_data"),
+            "Error should mention column name: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("ste_vec"),
+            "Error should mention ste_vec index: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("json"),
+            "Error should mention json cast_as requirement: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn ste_vec_with_json_cast_as_succeeds() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "users": {
+                    "event_data": {
+                        "cast_as": "json",
+                        "indexes": {
+                            "ste_vec": {
+                                "prefix": "event-data"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let result = serde_json::from_value::<EncryptConfig>(json)
+            .unwrap()
+            .into_config_map();
+
+        assert!(result.is_ok(), "ste_vec with json cast_as should succeed");
+        let config = result.unwrap();
+        let ident = Identifier::new("users", "event_data");
+        let column = config.get(&ident).expect("column exists");
+        assert_eq!(column.cast_type, ColumnType::JsonB);
     }
 }

--- a/crates/protect-ffi-c/src/go_plaintext.rs
+++ b/crates/protect-ffi-c/src/go_plaintext.rs
@@ -1,0 +1,376 @@
+use cipherstash_client::encryption::{Plaintext, TryFromPlaintext, TypeParseError};
+use cipherstash_client::schema::ColumnType;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[serde(untagged)]
+pub(crate) enum GoPlaintext {
+    String(String),
+    Number(f64),
+    Boolean(bool),
+    JsonB(serde_json::Value),
+}
+
+impl From<GoPlaintext> for Plaintext {
+    fn from(value: GoPlaintext) -> Self {
+        match value {
+            GoPlaintext::String(s) => Plaintext::Utf8Str(Some(s)),
+            GoPlaintext::Number(n) => Plaintext::Float(Some(n)),
+            GoPlaintext::Boolean(b) => Plaintext::Boolean(Some(b)),
+            GoPlaintext::JsonB(j) => Plaintext::JsonB(Some(j)),
+        }
+    }
+}
+
+impl TryFrom<Plaintext> for GoPlaintext {
+    type Error = TypeParseError;
+
+    fn try_from(value: Plaintext) -> Result<Self, Self::Error> {
+        match value {
+            v @ Plaintext::Utf8Str(Some(_)) => {
+                String::try_from_plaintext(v).map(GoPlaintext::String)
+            }
+            v @ Plaintext::JsonB(Some(_)) => {
+                serde_json::Value::try_from_plaintext(v).map(GoPlaintext::JsonB)
+            }
+            Plaintext::BigInt(Some(n)) => Ok(GoPlaintext::Number(n as f64)),
+            Plaintext::Float(Some(n)) => Ok(GoPlaintext::Number(n)),
+            Plaintext::Boolean(Some(b)) => Ok(GoPlaintext::Boolean(b)),
+            _ => Err(TypeParseError("Unsupported type".to_string())),
+        }
+    }
+}
+
+impl GoPlaintext {
+    /// Convert GoPlaintext to Plaintext based on a target ColumnType.
+    ///
+    /// This conversion follows the rule that type coercion is allowed but parsing is not.
+    /// For example:
+    /// - GoPlaintext::Number to Plaintext::BigInt is allowed (coercion with truncation)
+    /// - GoPlaintext::String to Plaintext::BigInt is NOT allowed (would require parsing)
+    pub fn to_plaintext_with_type(
+        &self,
+        column_type: ColumnType,
+    ) -> Result<Plaintext, TypeParseError> {
+        match (self, column_type) {
+            // String conversions - only allow to Utf8Str
+            (GoPlaintext::String(s), ColumnType::Utf8Str) => {
+                Ok(Plaintext::Utf8Str(Some(s.clone())))
+            }
+
+            // Number conversions - allow to numeric types with potential truncation/coercion
+            (GoPlaintext::Number(n), ColumnType::Float) => Ok(Plaintext::Float(Some(*n))),
+            (GoPlaintext::Number(n), ColumnType::Decimal) => Decimal::try_from(*n)
+                .map(|d| Plaintext::Decimal(Some(d)))
+                .map_err(|e| TypeParseError(format!("Cannot convert number to Decimal: {}", e))),
+            (GoPlaintext::Number(n), ColumnType::BigInt) => Ok(Plaintext::BigInt(Some(*n as i64))),
+            (GoPlaintext::Number(n), ColumnType::Int) => Ok(Plaintext::Int(Some(*n as i32))),
+            (GoPlaintext::Number(n), ColumnType::SmallInt) => {
+                Ok(Plaintext::SmallInt(Some(*n as i16)))
+            }
+            (GoPlaintext::Number(n), ColumnType::BigUInt) => {
+                if *n < 0.0 {
+                    Err(TypeParseError(
+                        "Cannot convert negative number to BigUInt".to_string(),
+                    ))
+                } else {
+                    Ok(Plaintext::BigUInt(Some(*n as u64)))
+                }
+            }
+
+            // Boolean conversions - only allow to Boolean
+            (GoPlaintext::Boolean(b), ColumnType::Boolean) => Ok(Plaintext::Boolean(Some(*b))),
+
+            // JsonB conversions - only allow to JsonB
+            (GoPlaintext::JsonB(j), ColumnType::JsonB) => Ok(Plaintext::JsonB(Some(j.clone()))),
+
+            // All other conversions are not allowed - provide helpful error message
+            (go_type, col_type) => {
+                let valid_targets = match go_type {
+                    GoPlaintext::String(_) => "Utf8Str (string columns)",
+                    GoPlaintext::Number(_) => {
+                        "Float, BigInt, Int, SmallInt, BigUInt, Decimal (numeric columns)"
+                    }
+                    GoPlaintext::Boolean(_) => "Boolean (boolean columns)",
+                    GoPlaintext::JsonB(_) => "JsonB (json columns)",
+                };
+                Err(TypeParseError(format!(
+                    "Cannot convert {} to {:?}. {} values can only be used with: {}. \
+                    Check your column's cast_as setting in the encrypt config.",
+                    go_plaintext_type_name(go_type),
+                    col_type,
+                    go_plaintext_type_name(go_type),
+                    valid_targets
+                )))
+            }
+        }
+    }
+}
+
+/// Helper function to get a readable type name for error messages
+pub(crate) fn go_plaintext_type_name(go_plaintext: &GoPlaintext) -> &'static str {
+    match go_plaintext {
+        GoPlaintext::String(_) => "String",
+        GoPlaintext::Number(_) => "Number",
+        GoPlaintext::Boolean(_) => "Boolean",
+        GoPlaintext::JsonB(_) => "JsonB",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod go_plaintext_to_plaintext {
+        use super::*;
+
+        #[test]
+        fn test_string() {
+            let go_string = GoPlaintext::String("hello".to_string());
+            let plaintext: Plaintext = go_string.into();
+            assert_eq!(plaintext, Plaintext::Utf8Str(Some("hello".to_string())));
+        }
+
+        #[test]
+        fn test_number() {
+            let go_number = GoPlaintext::Number(42.5);
+            let plaintext: Plaintext = go_number.into();
+            assert_eq!(plaintext, Plaintext::Float(Some(42.5)));
+        }
+
+        #[test]
+        fn test_boolean() {
+            let go_bool = GoPlaintext::Boolean(true);
+            let plaintext: Plaintext = go_bool.into();
+            assert_eq!(plaintext, Plaintext::Boolean(Some(true)));
+        }
+
+        #[test]
+        fn test_jsonb() {
+            let go_jsonb = GoPlaintext::JsonB(serde_json::json!({"key": "value"}));
+            let plaintext: Plaintext = go_jsonb.into();
+            assert_eq!(
+                plaintext,
+                Plaintext::JsonB(Some(serde_json::json!({"key": "value"})))
+            );
+        }
+    }
+
+    mod plaintext_to_go_plaintext {
+        use super::*;
+
+        #[test]
+        fn test_utf8str() {
+            let plaintext = Plaintext::Utf8Str(Some("hello".to_string()));
+            let go_plaintext: GoPlaintext = plaintext.try_into().unwrap();
+            assert_eq!(go_plaintext, GoPlaintext::String("hello".to_string()));
+        }
+
+        #[test]
+        fn test_float() {
+            let plaintext = Plaintext::Float(Some(42.5));
+            let go_plaintext: GoPlaintext = plaintext.try_into().unwrap();
+            assert_eq!(go_plaintext, GoPlaintext::Number(42.5));
+        }
+
+        #[test]
+        fn test_boolean() {
+            let plaintext = Plaintext::Boolean(Some(true));
+            let go_plaintext: GoPlaintext = plaintext.try_into().unwrap();
+            assert_eq!(go_plaintext, GoPlaintext::Boolean(true));
+        }
+
+        #[test]
+        fn test_jsonb() {
+            let plaintext = Plaintext::JsonB(Some(serde_json::json!({"key": "value"})));
+            let go_plaintext: GoPlaintext = plaintext.try_into().unwrap();
+            assert_eq!(
+                go_plaintext,
+                GoPlaintext::JsonB(serde_json::json!({"key": "value"}))
+            );
+        }
+
+        #[test]
+        fn test_bigint() {
+            let plaintext = Plaintext::BigInt(Some(42));
+            let go_plaintext: GoPlaintext = plaintext.try_into().unwrap();
+            assert_eq!(go_plaintext, GoPlaintext::Number(42.0));
+        }
+
+        #[test]
+        fn test_unsupported_type_returns_error() {
+            let plaintext = Plaintext::Utf8Str(None);
+            let result: Result<GoPlaintext, TypeParseError> = plaintext.try_into();
+            assert!(result.is_err());
+        }
+    }
+
+    mod go_plaintext_to_plaintext_with_type {
+        use super::*;
+
+        #[test]
+        fn test_string_to_utf8str() {
+            let go_string = GoPlaintext::String("hello".to_string());
+            let result = go_string
+                .to_plaintext_with_type(ColumnType::Utf8Str)
+                .unwrap();
+            assert_eq!(result, Plaintext::Utf8Str(Some("hello".to_string())));
+        }
+
+        #[test]
+        fn test_string_to_int_fails() {
+            let go_string = GoPlaintext::String("123".to_string());
+            let result = go_string.to_plaintext_with_type(ColumnType::Int);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().0.contains("Cannot convert"));
+        }
+
+        #[test]
+        fn test_number_to_float() {
+            let go_number = GoPlaintext::Number(3.78);
+            let result = go_number.to_plaintext_with_type(ColumnType::Float).unwrap();
+            assert_eq!(result, Plaintext::Float(Some(3.78)));
+        }
+
+        #[test]
+        fn test_number_to_decimal() {
+            let go_number = GoPlaintext::Number(3.78);
+            let result = go_number
+                .to_plaintext_with_type(ColumnType::Decimal)
+                .unwrap();
+            let expected_decimal = Decimal::try_from(3.78).unwrap();
+            assert_eq!(result, Plaintext::Decimal(Some(expected_decimal)));
+        }
+
+        #[test]
+        fn test_number_to_bigint_truncates() {
+            let go_number = GoPlaintext::Number(42.7);
+            let result = go_number
+                .to_plaintext_with_type(ColumnType::BigInt)
+                .unwrap();
+            assert_eq!(result, Plaintext::BigInt(Some(42)));
+        }
+
+        #[test]
+        fn test_number_to_int_truncates() {
+            let go_number = GoPlaintext::Number(42.7);
+            let result = go_number.to_plaintext_with_type(ColumnType::Int).unwrap();
+            assert_eq!(result, Plaintext::Int(Some(42)));
+        }
+
+        #[test]
+        fn test_number_to_smallint_truncates() {
+            let go_number = GoPlaintext::Number(42.7);
+            let result = go_number
+                .to_plaintext_with_type(ColumnType::SmallInt)
+                .unwrap();
+            assert_eq!(result, Plaintext::SmallInt(Some(42)));
+        }
+
+        #[test]
+        fn test_number_to_biguint() {
+            let go_number = GoPlaintext::Number(42.0);
+            let result = go_number
+                .to_plaintext_with_type(ColumnType::BigUInt)
+                .unwrap();
+            assert_eq!(result, Plaintext::BigUInt(Some(42)));
+        }
+
+        #[test]
+        fn test_negative_number_to_biguint_fails() {
+            let go_number = GoPlaintext::Number(-42.0);
+            let result = go_number.to_plaintext_with_type(ColumnType::BigUInt);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().0.contains("negative"));
+        }
+
+        #[test]
+        fn test_boolean_to_boolean() {
+            let go_bool = GoPlaintext::Boolean(true);
+            let result = go_bool.to_plaintext_with_type(ColumnType::Boolean).unwrap();
+            assert_eq!(result, Plaintext::Boolean(Some(true)));
+        }
+
+        #[test]
+        fn test_boolean_to_string_fails() {
+            let go_bool = GoPlaintext::Boolean(true);
+            let result = go_bool.to_plaintext_with_type(ColumnType::Utf8Str);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().0.contains("Cannot convert"));
+        }
+
+        #[test]
+        fn test_jsonb_to_jsonb() {
+            let json_value = serde_json::json!({"key": "value"});
+            let go_jsonb = GoPlaintext::JsonB(json_value.clone());
+            let result = go_jsonb.to_plaintext_with_type(ColumnType::JsonB).unwrap();
+            assert_eq!(result, Plaintext::JsonB(Some(json_value)));
+        }
+
+        #[test]
+        fn test_jsonb_to_string_fails() {
+            let json_value = serde_json::json!({"key": "value"});
+            let go_jsonb = GoPlaintext::JsonB(json_value);
+            let result = go_jsonb.to_plaintext_with_type(ColumnType::Utf8Str);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().0.contains("Cannot convert"));
+        }
+
+        #[test]
+        fn test_number_to_boolean_fails() {
+            let go_number = GoPlaintext::Number(1.0);
+            let result = go_number.to_plaintext_with_type(ColumnType::Boolean);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().0.contains("Cannot convert"));
+        }
+
+        #[test]
+        fn test_type_coercion_error_shows_valid_alternatives() {
+            let go_string = GoPlaintext::String("hello".to_string());
+            let result = go_string.to_plaintext_with_type(ColumnType::Int);
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err().0;
+            assert!(
+                err_msg.contains("Utf8Str"),
+                "Error should mention valid target Utf8Str: {}",
+                err_msg
+            );
+            assert!(
+                err_msg.contains("cast_as"),
+                "Error should mention cast_as setting: {}",
+                err_msg
+            );
+
+            let go_number = GoPlaintext::Number(42.0);
+            let result = go_number.to_plaintext_with_type(ColumnType::Boolean);
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err().0;
+            assert!(
+                err_msg.contains("Float") || err_msg.contains("BigInt"),
+                "Error should mention valid numeric targets: {}",
+                err_msg
+            );
+
+            let go_bool = GoPlaintext::Boolean(true);
+            let result = go_bool.to_plaintext_with_type(ColumnType::Int);
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err().0;
+            assert!(
+                err_msg.contains("Boolean"),
+                "Error should mention valid target Boolean: {}",
+                err_msg
+            );
+
+            let go_json = GoPlaintext::JsonB(serde_json::json!({"a": 1}));
+            let result = go_json.to_plaintext_with_type(ColumnType::Int);
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err().0;
+            assert!(
+                err_msg.contains("JsonB"),
+                "Error should mention valid target JsonB: {}",
+                err_msg
+            );
+        }
+    }
+}

--- a/crates/protect-ffi-c/src/lib.rs
+++ b/crates/protect-ffi-c/src/lib.rs
@@ -1,31 +1,46 @@
-use cipherstash_client::{
-    config::{
-        console_config::ConsoleConfig, cts_config::CtsConfig, errors::ConfigError,
-        zero_kms_config::ZeroKMSConfig, CipherStashConfigFile, CipherStashSecretConfigFile,
-        EnvSource, FileSource,
-    },
-    credentials::{ServiceCredentials, ServiceToken},
-    encryption::{
-        self, EncryptionError, IndexTerm, Plaintext, PlaintextTarget, ReferencedPendingPipeline,
-        ScopedCipher, SteVec, TypeParseError,
-    },
-    schema::ColumnConfig,
-    zerokms::{self, EncryptedRecord, RecordDecryptError, WithContext, ZeroKMSWithClientKey},
-    UnverifiedContext,
-};
-use cts_common::Crn;
-use once_cell::sync::OnceCell;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
-use std::sync::Arc;
-use tokio::runtime::Runtime;
+// FFI functions intentionally accept raw pointers in `extern "C"` signatures
+// that are validated (null-checked) before dereferencing. Marking every FFI
+// function `unsafe` would change the C header signature, which is undesirable.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 mod encrypt_config;
-use encrypt_config::{EncryptConfig, Identifier};
+mod go_plaintext;
 
-// Error handling
+use cipherstash_client::{
+    credentials::ServiceToken,
+    encryption::{EncryptionError, Plaintext, QueryOp, ScopedCipher, TypeParseError},
+    eql::{
+        encrypt_eql, EqlCiphertext, EqlEncryptOpts, EqlError, EqlOperation,
+        Identifier as EqlIdentifier, PreparedPlaintext,
+    },
+    schema::{
+        column::{Index, IndexType},
+        ColumnConfig,
+    },
+    zerokms::{
+        self, FallbackKeyProvider, RecordDecryptError, SecretKey, WithContext, ZeroKMSBuilder,
+        ZeroKMSBuilderError, ZeroKMSWithClientKey,
+    },
+    AuthError, AutoStrategy, IdentifiedBy, UnverifiedContext,
+};
+use cts_common::Crn;
+use encrypt_config::{EncryptConfig, Identifier};
+use go_plaintext::GoPlaintext;
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap},
+    ffi::{CStr, CString},
+    os::raw::c_char,
+    sync::Arc,
+};
+use tokio::runtime::Runtime;
+
+// ---------------------------------------------------------------------------
+// C FFI result type
+// ---------------------------------------------------------------------------
+
 #[repr(C)]
 pub struct CResult {
     pub success: bool,
@@ -43,80 +58,305 @@ impl Default for CResult {
     }
 }
 
-// Client structure that we'll pass around as an opaque pointer
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+type ScopedZeroKMS = ScopedCipher<AutoStrategy>;
+
+/// Opaque client handle passed across the FFI boundary.
 #[derive(Clone)]
 pub struct Client {
-    cipher: Arc<ScopedZeroKMSNoRefresh>,
-    zerokms: Arc<ZeroKMSWithClientKey<ServiceCredentials>>,
+    cipher: Arc<ScopedZeroKMS>,
+    zerokms: Arc<ZeroKMSWithClientKey<AutoStrategy>>,
     encrypt_config: Arc<HashMap<Identifier, ColumnConfig>>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(tag = "k")]
-pub enum Encrypted {
-    #[serde(rename = "ct")]
-    Ciphertext {
-        #[serde(rename = "c")]
-        ciphertext: String,
-        #[serde(rename = "ob")]
-        ore_index: Option<Vec<String>>,
-        #[serde(rename = "bf")]
-        match_index: Option<Vec<u16>>,
-        #[serde(rename = "hm")]
-        unique_index: Option<String>,
-        #[serde(rename = "i")]
-        identifier: Identifier,
-        #[serde(rename = "v")]
-        version: u16,
-    },
-    #[serde(rename = "sv")]
-    SteVec {
-        #[serde(rename = "sv")]
-        ste_vec_index: SteVec<16>,
-        #[serde(rename = "i")]
-        identifier: Identifier,
-        #[serde(rename = "v")]
-        version: u16,
-    },
+/// Re-export EqlCiphertext as Encrypted for backward compatibility.
+///
+/// This is a unified structure that contains the identifier, version, and the encrypted body
+/// with all associated cryptographic searchable encrypted metadata (SEM).
+///
+/// Note: The ciphertext field (c) is serialized in MessagePack Base85 format.
+pub type Encrypted = EqlCiphertext;
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+/// What type of value was received in a query
+#[derive(Debug, Clone)]
+pub enum ReceivedKind {
+    String(String),
+    Number(f64),
+    Boolean(bool),
+    JsonObject,
+    JsonArray,
+    JsonScalar(String),
+}
+
+impl std::fmt::Display for ReceivedKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::String(s) => write!(f, "String \"{}\"", truncate_for_error(s, 30)),
+            Self::Number(n) => write!(f, "Number {}", n),
+            Self::Boolean(b) => write!(f, "Boolean {}", b),
+            Self::JsonObject => write!(f, "JSON object"),
+            Self::JsonArray => write!(f, "JSON array"),
+            Self::JsonScalar(s) => write!(f, "JSON scalar {}", s),
+        }
+    }
+}
+
+impl ReceivedKind {
+    /// Introspect JSON values so object/array are distinguished.
+    pub fn from_json(value: &serde_json::Value) -> Self {
+        match value {
+            serde_json::Value::Object(_) => Self::JsonObject,
+            serde_json::Value::Array(_) => Self::JsonArray,
+            serde_json::Value::String(s) => Self::JsonScalar(format!("\"{}\"", s)),
+            serde_json::Value::Number(n) => Self::JsonScalar(n.to_string()),
+            serde_json::Value::Bool(b) => Self::JsonScalar(b.to_string()),
+            serde_json::Value::Null => Self::JsonScalar("null".to_string()),
+        }
+    }
+}
+
+/// What type of value was expected
+#[derive(Debug, Clone, Copy)]
+pub enum ExpectedKind {
+    JsonObjectOrArray,
+    StringPathOrJsonObjectOrArray,
+}
+
+impl std::fmt::Display for ExpectedKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::JsonObjectOrArray => write!(f, "JSON object or array"),
+            Self::StringPathOrJsonObjectOrArray => {
+                write!(f, "String (JSON path) or JSON object/array")
+            }
+        }
+    }
+}
+
+/// Query operation context for errors
+#[derive(Debug, Clone, Copy)]
+pub enum QueryOpKind {
+    SteVecTerm,
+    SteVecDefault,
+}
+
+impl std::fmt::Display for QueryOpKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SteVecTerm => write!(f, "ste_vec_term"),
+            Self::SteVecDefault => write!(f, "ste_vec (default)"),
+        }
+    }
+}
+
+/// Wrapper for bounded display of potentially large strings
+#[derive(Debug, Clone)]
+pub struct Truncated<'a> {
+    value: Cow<'a, str>,
+    max_len: usize,
+}
+
+impl<'a> Truncated<'a> {
+    pub fn new(value: impl Into<Cow<'a, str>>, max_len: usize) -> Self {
+        Self {
+            value: value.into(),
+            max_len,
+        }
+    }
+
+    pub fn path(value: impl Into<Cow<'a, str>>) -> Self {
+        Self::new(value, 50)
+    }
+}
+
+impl std::fmt::Display for Truncated<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.value.chars().count() <= self.max_len {
+            write!(f, "{}", self.value)
+        } else {
+            let truncated: String = self.value.chars().take(self.max_len).collect();
+            write!(f, "{}...", truncated)
+        }
+    }
+}
+
+/// Hints for InvalidQueryInput errors
+#[derive(Debug, Clone, Copy)]
+pub enum QueryInputHint {
+    UseSelectorForPath,
+    WrapInObject,
+    WrapNumberInObject,
+    WrapBooleanInObject,
+    UsePathOrObject,
+}
+
+impl std::fmt::Display for QueryInputHint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UseSelectorForPath => write!(f, "For path queries like '$.field', use queryOp: 'ste_vec_selector'. For containment queries, wrap the value in an object: {{\"field\": \"value\"}}."),
+            Self::WrapInObject => write!(f, "Wrap the value in a JSON object: {{\"field\": value}}."),
+            Self::WrapNumberInObject => write!(f, "Wrap the number in a JSON object to query by value: {{\"field\": <number>}}."),
+            Self::WrapBooleanInObject => write!(f, "Wrap the boolean in a JSON object to query by value: {{\"field\": <boolean>}}."),
+            Self::UsePathOrObject => write!(f, "Use a JSON path string like '$.field' for path queries, or a JSON object like {{\"field\": value}} for containment queries."),
+        }
+    }
+}
+
+/// Reasons for JSON path errors
+#[derive(Debug, Clone, Copy)]
+pub enum JsonPathReason {
+    Empty,
+    MissingDollar,
+}
+
+impl std::fmt::Display for JsonPathReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "path cannot be empty"),
+            Self::MissingDollar => write!(f, "path must start with '$'"),
+        }
+    }
+}
+
+/// Hints for JSON path errors
+#[derive(Debug, Clone)]
+pub enum JsonPathHint {
+    TryPrefix(String),
+}
+
+impl std::fmt::Display for JsonPathHint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TryPrefix(path) => write!(f, "Try: '$.{}' or '$[\"{}\"]'.", path, path),
+        }
+    }
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("Configuration error: {0}")]
+    Config(String),
     #[error(transparent)]
-    Config(#[from] ConfigError),
+    ZeroKMSBuilder(#[from] ZeroKMSBuilderError),
+    #[error(transparent)]
+    Auth(#[from] AuthError),
     #[error(transparent)]
     ZeroKMS(#[from] zerokms::Error),
     #[error(transparent)]
     TypeParse(#[from] TypeParseError),
     #[error(transparent)]
     Encryption(#[from] EncryptionError),
-    #[error("protect-ffi invariant violation: {0}. This is a bug in protect-ffi. Please file an issue at https://github.com/cipherstash/protectgo/issues.")]
+    #[error(transparent)]
+    Eql(#[from] EqlError),
+    #[error("protect-ffi invariant violation: {0}. This is a bug in protect-ffi.")]
     InvariantViolation(String),
-    #[error("{0}")]
-    Base85(String),
-    #[error("unimplemented: {0} not supported yet by protect-ffi")]
-    Unimplemented(String),
+    #[error("Unknown query operation: '{0}'")]
+    UnknownQueryOp(String),
     #[error(transparent)]
     Parse(#[from] serde_json::Error),
     #[error("column {}.{} not found in Encrypt config", _0.table, _0.column)]
     UnknownColumn(Identifier),
     #[error(transparent)]
     RecordDecryptError(#[from] RecordDecryptError),
+    #[error("Column '{column}' does not have a '{index_type}' index configured. {hint}")]
+    MissingIndex {
+        column: String,
+        index_type: String,
+        hint: String,
+    },
+    #[error(
+        "Invalid query input for '{query_op}': received {received}, expected {expected}. {hint}"
+    )]
+    InvalidQueryInput {
+        query_op: QueryOpKind,
+        received: ReceivedKind,
+        expected: ExpectedKind,
+        hint: QueryInputHint,
+    },
+    #[error("Invalid JSON path '{path}': {reason}. {hint}")]
+    InvalidJsonPath {
+        path: Truncated<'static>,
+        reason: JsonPathReason,
+        hint: JsonPathHint,
+    },
+    #[error("Configuration error for column '{table}.{column}': ste_vec index requires cast_as: 'json', but found cast_as: '{found_cast_as}'. Either change cast_as to 'json' or remove the ste_vec index.")]
+    SteVecRequiresJsonCastAs {
+        table: String,
+        column: String,
+        found_cast_as: String,
+    },
     #[error("null pointer error")]
     NullPointer,
     #[error("utf8 conversion error")]
     Utf8Error,
 }
 
-type ScopedZeroKMSNoRefresh = ScopedCipher<ServiceCredentials>;
+// ---------------------------------------------------------------------------
+// Configuration / credential types
+// ---------------------------------------------------------------------------
 
+/// Credential fields shared by [`ClientOpts`].
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
-struct ClientOpts {
+struct CredentialOpts {
     workspace_crn: Option<Crn>,
     access_key: Option<String>,
     client_id: Option<String>,
     client_key: Option<String>,
+}
+
+impl CredentialOpts {
+    /// Build an [`AutoStrategy`] from optional workspace CRN and access key,
+    /// falling back to env vars and profile store for unset fields.
+    fn build_strategy(&self) -> Result<AutoStrategy, Error> {
+        let mut builder = AutoStrategy::builder();
+        if let Some(key) = self.access_key.as_ref() {
+            builder = builder.with_access_key(key);
+        }
+        if let Some(crn) = self.workspace_crn.as_ref() {
+            builder = builder.with_workspace_crn(crn.clone());
+        }
+        Ok(builder.detect()?)
+    }
+
+    /// Build an `Option<SecretKey>` from the `client_id` + `client_key` pair.
+    ///
+    /// Returns `None` if either field is missing (triggers `FallbackKeyProvider` to try the
+    /// profile store). Returns `Err` if the values are present but invalid.
+    fn secret_key(&self) -> Result<Option<SecretKey>, Error> {
+        match (self.client_id.as_ref(), self.client_key.as_ref()) {
+            (Some(id), Some(key)) => SecretKey::from_hex(id.clone(), key.clone())
+                .map(Some)
+                .map_err(|e| Error::Config(e.to_string())),
+            _ => Ok(None),
+        }
+    }
+
+    /// Build a key provider that resolves the client key from explicit fields,
+    /// falling back to the profile store (`~/.cipherstash/secretkey.json`).
+    fn build_key_provider(
+        &self,
+    ) -> Result<FallbackKeyProvider<Option<SecretKey>, stack_profile::ProfileStore>, Error> {
+        Ok(FallbackKeyProvider::new(
+            self.secret_key()?,
+            stack_profile::ProfileStore::default(),
+        ))
+    }
+}
+
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct ClientOpts {
+    #[serde(flatten)]
+    creds: CredentialOpts,
+    keyset: Option<IdentifiedBy>,
 }
 
 #[derive(Deserialize)]
@@ -126,17 +366,21 @@ struct NewClientOptions {
     client_opts: Option<ClientOpts>,
 }
 
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 enum DecryptResult {
-    Success { data: String },
+    Success { data: GoPlaintext },
     Error { error: String },
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct EncryptOptions {
-    plaintext: String,
+    plaintext: GoPlaintext,
     column: String,
     table: String,
     lock_context: Option<LockContext>,
@@ -155,16 +399,61 @@ struct EncryptBulkOptions {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PlaintextPayload {
-    plaintext: String,
+    plaintext: GoPlaintext,
     column: String,
     table: String,
+    /// Lock context for this payload. Payloads with different lock_context values
+    /// will be encrypted in separate batches to preserve per-payload context binding.
+    lock_context: Option<LockContext>,
+}
+
+/// Options for encrypting a query term (search predicate)
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EncryptQueryOptions {
+    plaintext: GoPlaintext,
+    column: String,
+    table: String,
+    /// The index type to use: "ste_vec", "match", "ore", "unique"
+    index_type: String,
+    /// The query operation: "default", "ste_vec_selector", "ste_vec_term"
+    #[serde(default = "default_query_op")]
+    query_op: String,
+    lock_context: Option<LockContext>,
+    service_token: Option<ServiceToken>,
+    unverified_context: Option<UnverifiedContext>,
+}
+
+fn default_query_op() -> String {
+    "default".to_string()
+}
+
+/// Options for bulk query encryption
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EncryptQueryBulkOptions {
+    queries: Vec<QueryPayload>,
+    service_token: Option<ServiceToken>,
+    unverified_context: Option<UnverifiedContext>,
+}
+
+/// Individual query payload for bulk operations
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct QueryPayload {
+    plaintext: GoPlaintext,
+    column: String,
+    table: String,
+    index_type: String,
+    #[serde(default = "default_query_op")]
+    query_op: String,
     lock_context: Option<LockContext>,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct DecryptOptions {
-    ciphertext: String,
+    ciphertext: Encrypted,
     lock_context: Option<LockContext>,
     service_token: Option<ServiceToken>,
     unverified_context: Option<UnverifiedContext>,
@@ -181,7 +470,7 @@ struct DecryptBulkOptions {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct BulkDecryptPayload {
-    ciphertext: String,
+    ciphertext: Encrypted,
     lock_context: Option<LockContext>,
 }
 
@@ -200,14 +489,20 @@ impl From<LockContext> for Vec<zerokms::Context> {
     }
 }
 
+// ---------------------------------------------------------------------------
 // Runtime management
+// ---------------------------------------------------------------------------
+
 static RUNTIME: OnceCell<Runtime> = OnceCell::new();
 
 fn get_runtime() -> &'static Runtime {
     RUNTIME.get_or_init(|| Runtime::new().expect("Failed to create tokio runtime"))
 }
 
-// Helper functions for string conversion
+// ---------------------------------------------------------------------------
+// String conversion helpers
+// ---------------------------------------------------------------------------
+
 unsafe fn c_str_to_string(c_str: *const c_char) -> Result<String, Error> {
     if c_str.is_null() {
         return Err(Error::NullPointer);
@@ -225,12 +520,658 @@ fn string_to_c_str(s: String) -> *const c_char {
     }
 }
 
-// Exported C functions
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+/// Truncate a string for error messages
+fn truncate_for_error(s: &str, max_len: usize) -> String {
+    if max_len == 0 {
+        return "...".to_string();
+    }
+    let mut out = String::new();
+    let mut iter = s.chars();
+    for _ in 0..max_len {
+        match iter.next() {
+            Some(ch) => out.push(ch),
+            None => return s.to_string(),
+        }
+    }
+    if iter.next().is_none() {
+        return s.to_string();
+    }
+    format!("{}...", out)
+}
+
+/// Validate a JSON path string
+fn validate_json_path(path: &str) -> Result<(), Error> {
+    if path.is_empty() {
+        return Err(Error::InvalidJsonPath {
+            path: Truncated::path(path.to_string()),
+            reason: JsonPathReason::Empty,
+            hint: JsonPathHint::TryPrefix(path.to_string()),
+        });
+    }
+    if !path.starts_with('$') {
+        return Err(Error::InvalidJsonPath {
+            path: Truncated::path(path.to_string()),
+            reason: JsonPathReason::MissingDollar,
+            hint: JsonPathHint::TryPrefix(path.to_string()),
+        });
+    }
+    Ok(())
+}
+
+/// Get a description of what an index type is used for
+fn index_type_description(index_type: &str) -> &'static str {
+    match index_type {
+        "ste_vec" => "JSON path and containment queries",
+        "ore" => "range comparisons (<, >, <=, >=)",
+        "match" => "full-text search queries",
+        "unique" => "exact match queries",
+        _ => "unknown query type",
+    }
+}
+
+/// Format available indexes on a column for error messages
+fn format_available_indexes(column_config: &ColumnConfig) -> String {
+    let available: Vec<&str> = column_config
+        .indexes
+        .iter()
+        .map(|idx| match &idx.index_type {
+            IndexType::SteVec { .. } => "ste_vec",
+            IndexType::Match { .. } => "match",
+            IndexType::Ore => "ore",
+            IndexType::Unique { .. } => "unique",
+        })
+        .collect();
+
+    if available.is_empty() {
+        "No indexes are configured for this column.".to_string()
+    } else {
+        format!("Available indexes: {}.", available.join(", "))
+    }
+}
+
+/// Find the matching index from column config by index type name
+fn find_index_for_type<'a>(
+    column_config: &'a ColumnConfig,
+    column_name: &str,
+    index_type_name: &str,
+) -> Result<&'a Index, Error> {
+    column_config
+        .indexes
+        .iter()
+        .find(|idx| {
+            matches!(
+                (&idx.index_type, index_type_name),
+                (IndexType::SteVec { .. }, "ste_vec")
+                    | (IndexType::Match { .. }, "match")
+                    | (IndexType::Ore, "ore")
+                    | (IndexType::Unique { .. }, "unique")
+            )
+        })
+        .ok_or_else(|| {
+            let available = format_available_indexes(column_config);
+            let description = index_type_description(index_type_name);
+            Error::MissingIndex {
+                column: column_name.to_string(),
+                index_type: index_type_name.to_string(),
+                hint: format!(
+                    "{} Add an '{}' index to enable {}.",
+                    available, index_type_name, description
+                ),
+            }
+        })
+}
+
+/// Parse query operation string to QueryOp enum
+fn parse_query_op(query_op: &str) -> Result<QueryOp, Error> {
+    match query_op {
+        "default" => Ok(QueryOp::Default),
+        "ste_vec_selector" => Ok(QueryOp::SteVecSelector),
+        "ste_vec_term" => Ok(QueryOp::SteVecTerm),
+        _ => Err(Error::UnknownQueryOp(query_op.to_string())),
+    }
+}
+
+/// Inferred operation mode for query encryption.
+///
+/// This determines which EqlOperation to use:
+/// - QueryMode: Use EqlOperation::Query (standard query encryption)
+/// - StoreMode: Use EqlOperation::Store (for containment queries that need sv array)
+#[derive(Debug, Clone, Copy)]
+enum InferredQueryMode {
+    /// Use EqlOperation::Query with the given QueryOp
+    QueryMode(QueryOp),
+    /// Use EqlOperation::Store (for JSON containment queries on ste_vec)
+    StoreMode,
+}
+
+/// Convert GoPlaintext to Plaintext and infer the appropriate operation mode.
+///
+/// Returns both the converted Plaintext and the inferred operation mode.
+///
+/// Query mode has different type semantics than storage mode:
+/// - SteVecSelector: Always string (JSON path like "$.user.email") -> QueryMode
+/// - SteVecTerm: Always JSON (fragment to match with @>) -> StoreMode (produces sv array)
+/// - Default: For SteVec indexes, infers from plaintext type:
+///   - String -> QueryMode with SteVecSelector (path queries)
+///   - JsonB (Object/Array) -> StoreMode (containment queries need sv array)
+///   - Other indexes use column's cast_type and QueryMode with Default
+fn to_query_plaintext(
+    go_plaintext: &GoPlaintext,
+    query_op: QueryOp,
+    index_type: &IndexType,
+    column_type: cipherstash_client::schema::column::ColumnType,
+) -> Result<(Plaintext, InferredQueryMode), Error> {
+    use cipherstash_client::schema::column::ColumnType;
+
+    match query_op {
+        QueryOp::SteVecSelector => {
+            // Selector queries expect a string path like "$.user.email"
+            // Validate the path if we have a string
+            if let GoPlaintext::String(path) = go_plaintext {
+                validate_json_path(path)?;
+            }
+            // Force Utf8Str conversion regardless of column type
+            let plaintext = go_plaintext.to_plaintext_with_type(ColumnType::Utf8Str)?;
+            Ok((
+                plaintext,
+                InferredQueryMode::QueryMode(QueryOp::SteVecSelector),
+            ))
+        }
+        QueryOp::SteVecTerm => {
+            // Term queries expect a JSON fragment to match with @>
+            // Provide helpful errors for wrong types
+            match go_plaintext {
+                GoPlaintext::String(s) => {
+                    return Err(Error::InvalidQueryInput {
+                        query_op: QueryOpKind::SteVecTerm,
+                        received: ReceivedKind::String(s.clone()),
+                        expected: ExpectedKind::JsonObjectOrArray,
+                        hint: QueryInputHint::UseSelectorForPath,
+                    });
+                }
+                GoPlaintext::Number(n) => {
+                    return Err(Error::InvalidQueryInput {
+                        query_op: QueryOpKind::SteVecTerm,
+                        received: ReceivedKind::Number(*n),
+                        expected: ExpectedKind::JsonObjectOrArray,
+                        hint: QueryInputHint::WrapNumberInObject,
+                    });
+                }
+                GoPlaintext::Boolean(b) => {
+                    return Err(Error::InvalidQueryInput {
+                        query_op: QueryOpKind::SteVecTerm,
+                        received: ReceivedKind::Boolean(*b),
+                        expected: ExpectedKind::JsonObjectOrArray,
+                        hint: QueryInputHint::WrapBooleanInObject,
+                    });
+                }
+                GoPlaintext::JsonB(_) => {
+                    // This is the expected type - proceed
+                }
+            }
+            // Use Store mode to produce sv array for containment matching
+            let plaintext = go_plaintext.to_plaintext_with_type(ColumnType::JsonB)?;
+            Ok((plaintext, InferredQueryMode::StoreMode))
+        }
+        QueryOp::Default => {
+            // For SteVec indexes with Default queryOp, infer from plaintext type
+            if matches!(index_type, IndexType::SteVec { .. }) {
+                match go_plaintext {
+                    GoPlaintext::String(path) => {
+                        // String -> selector (path queries like "$.user.email")
+                        validate_json_path(path)?;
+                        let plaintext = go_plaintext.to_plaintext_with_type(ColumnType::Utf8Str)?;
+                        Ok((
+                            plaintext,
+                            InferredQueryMode::QueryMode(QueryOp::SteVecSelector),
+                        ))
+                    }
+                    GoPlaintext::JsonB(_) => {
+                        // Object/Array -> Store mode for containment queries
+                        // This produces sv array needed for @> operator matching
+                        let plaintext = go_plaintext.to_plaintext_with_type(ColumnType::JsonB)?;
+                        Ok((plaintext, InferredQueryMode::StoreMode))
+                    }
+                    GoPlaintext::Number(n) => Err(Error::InvalidQueryInput {
+                        query_op: QueryOpKind::SteVecDefault,
+                        received: ReceivedKind::Number(*n),
+                        expected: ExpectedKind::StringPathOrJsonObjectOrArray,
+                        hint: QueryInputHint::UsePathOrObject,
+                    }),
+                    GoPlaintext::Boolean(b) => Err(Error::InvalidQueryInput {
+                        query_op: QueryOpKind::SteVecDefault,
+                        received: ReceivedKind::Boolean(*b),
+                        expected: ExpectedKind::StringPathOrJsonObjectOrArray,
+                        hint: QueryInputHint::UsePathOrObject,
+                    }),
+                }
+            } else {
+                // Non-SteVec indexes: use column's storage type (original behavior)
+                let plaintext = go_plaintext.to_plaintext_with_type(column_type)?;
+                Ok((plaintext, InferredQueryMode::QueryMode(QueryOp::Default)))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core async implementations
+// ---------------------------------------------------------------------------
+
+async fn new_client_impl(opts: NewClientOptions) -> Result<Client, Error> {
+    let client_opts = opts.client_opts.unwrap_or_default();
+
+    let strategy = client_opts.creds.build_strategy()?;
+    let zerokms = ZeroKMSBuilder::new(strategy)
+        .with_key_provider(client_opts.creds.build_key_provider()?)
+        .build()
+        .await?;
+
+    let zerokms = Arc::new(zerokms);
+    let cipher = ScopedZeroKMS::init(zerokms.clone(), client_opts.keyset).await?;
+
+    let client = Client {
+        cipher: Arc::new(cipher),
+        zerokms,
+        encrypt_config: Arc::new(opts.encrypt_config.into_config_map()?),
+    };
+
+    Ok(client)
+}
+
+async fn encrypt_impl(client: &Client, opts: EncryptOptions) -> Result<Encrypted, Error> {
+    let ident = Identifier::new(opts.table.clone(), opts.column.clone());
+
+    let column_config = client
+        .encrypt_config
+        .get(&ident)
+        .ok_or_else(|| Error::UnknownColumn(ident.clone()))?;
+
+    let plaintext = opts
+        .plaintext
+        .to_plaintext_with_type(column_config.cast_type)?;
+
+    let eql_ident = EqlIdentifier::new(&opts.table, &opts.column);
+    let prepared = PreparedPlaintext::new(
+        Cow::Borrowed(column_config),
+        eql_ident,
+        plaintext,
+        EqlOperation::Store,
+    );
+
+    let eql_opts = EqlEncryptOpts {
+        keyset_id: None,
+        lock_context: Cow::Owned(opts.lock_context.map(Into::into).unwrap_or_default()),
+        service_token: opts.service_token.map(Cow::Owned),
+        unverified_context: opts.unverified_context.map(Cow::Owned),
+        index_types: None,
+    };
+
+    let mut encrypted = encrypt_eql(client.cipher.clone(), vec![prepared], &eql_opts).await?;
+    Ok(encrypted.remove(0))
+}
+
+async fn encrypt_bulk_impl(
+    client: &Client,
+    opts: EncryptBulkOptions,
+) -> Result<Vec<Encrypted>, Error> {
+    // Group payloads by lock_context for batch processing
+    // BTreeMap provides deterministic ordering of groups
+    let mut groups: BTreeMap<Vec<String>, Vec<(usize, PlaintextPayload)>> = BTreeMap::new();
+
+    for (idx, payload) in opts.plaintexts.into_iter().enumerate() {
+        let key = payload
+            .lock_context
+            .as_ref()
+            .map(|lc| lc.identity_claim.clone())
+            .unwrap_or_default();
+        groups.entry(key).or_default().push((idx, payload));
+    }
+
+    // Pre-allocate results vector
+    let total_count: usize = groups.values().map(|g| g.len()).sum();
+    let mut results: Vec<Option<EqlCiphertext>> = (0..total_count).map(|_| None).collect();
+
+    // Process each lock_context group
+    for (lock_context_claims, payloads) in groups {
+        let lock_context: Vec<zerokms::Context> = lock_context_claims
+            .into_iter()
+            .map(zerokms::Context::IdentityClaim)
+            .collect();
+
+        // Build PreparedPlaintext items for this group
+        let mut prepared_plaintexts = Vec::with_capacity(payloads.len());
+        let mut payload_data: Vec<(usize, Identifier)> = Vec::with_capacity(payloads.len());
+
+        for (original_idx, payload) in payloads {
+            let ident = Identifier::new(payload.table.clone(), payload.column.clone());
+
+            let column_config = client
+                .encrypt_config
+                .get(&ident)
+                .ok_or_else(|| Error::UnknownColumn(ident.clone()))?;
+
+            let plaintext = payload
+                .plaintext
+                .to_plaintext_with_type(column_config.cast_type)?;
+
+            let eql_ident = EqlIdentifier::new(&payload.table, &payload.column);
+            let prepared = PreparedPlaintext::new(
+                Cow::Borrowed(column_config),
+                eql_ident,
+                plaintext,
+                EqlOperation::Store,
+            );
+
+            prepared_plaintexts.push(prepared);
+            payload_data.push((original_idx, ident));
+        }
+
+        let eql_opts = EqlEncryptOpts {
+            keyset_id: None,
+            lock_context: Cow::Owned(lock_context),
+            service_token: opts.service_token.as_ref().map(Cow::Borrowed),
+            unverified_context: opts.unverified_context.as_ref().map(Cow::Borrowed),
+            index_types: None,
+        };
+
+        let encrypted = encrypt_eql(client.cipher.clone(), prepared_plaintexts, &eql_opts).await?;
+
+        // Place results back in original order
+        for (eql_ciphertext, (original_idx, _ident)) in encrypted.into_iter().zip(payload_data) {
+            results[original_idx] = Some(eql_ciphertext);
+        }
+    }
+
+    // Unwrap all results (all should be Some)
+    results
+        .into_iter()
+        .enumerate()
+        .map(|(i, opt)| {
+            opt.ok_or_else(|| {
+                Error::InvariantViolation(format!("Missing encryption result for index {}", i))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
+async fn encrypt_query_impl(
+    client: &Client,
+    opts: EncryptQueryOptions,
+) -> Result<EqlCiphertext, Error> {
+    let ident = Identifier::new(opts.table.clone(), opts.column.clone());
+
+    let column_config = client
+        .encrypt_config
+        .get(&ident)
+        .ok_or_else(|| Error::UnknownColumn(ident.clone()))?;
+
+    // Find the requested index type from column config
+    let index = find_index_for_type(column_config, &opts.column, &opts.index_type)?;
+    let query_op = parse_query_op(&opts.query_op)?;
+
+    // Infer type and operation mode from plaintext
+    let (plaintext, inferred_mode) = to_query_plaintext(
+        &opts.plaintext,
+        query_op,
+        &index.index_type,
+        column_config.cast_type,
+    )?;
+
+    // Select the appropriate EqlOperation based on inferred mode
+    let eql_operation = match inferred_mode {
+        InferredQueryMode::QueryMode(qop) => EqlOperation::Query(&index.index_type, qop),
+        InferredQueryMode::StoreMode => EqlOperation::Store,
+    };
+
+    let eql_ident = EqlIdentifier::new(&opts.table, &opts.column);
+    let prepared = PreparedPlaintext::new(
+        Cow::Borrowed(column_config),
+        eql_ident,
+        plaintext,
+        eql_operation,
+    );
+
+    let eql_opts = EqlEncryptOpts {
+        keyset_id: None,
+        lock_context: Cow::Owned(opts.lock_context.map(Into::into).unwrap_or_default()),
+        service_token: opts.service_token.map(Cow::Owned),
+        unverified_context: opts.unverified_context.map(Cow::Owned),
+        index_types: None,
+    };
+
+    let mut encrypted = encrypt_eql(client.cipher.clone(), vec![prepared], &eql_opts).await?;
+    Ok(encrypted.remove(0))
+}
+
+async fn encrypt_query_bulk_impl(
+    client: &Client,
+    opts: EncryptQueryBulkOptions,
+) -> Result<Vec<EqlCiphertext>, Error> {
+    // Group payloads by lock_context (same pattern as encrypt_bulk)
+    let mut groups: BTreeMap<Vec<String>, Vec<(usize, QueryPayload)>> = BTreeMap::new();
+
+    for (idx, payload) in opts.queries.into_iter().enumerate() {
+        let key = payload
+            .lock_context
+            .as_ref()
+            .map(|lc| lc.identity_claim.clone())
+            .unwrap_or_default();
+        groups.entry(key).or_default().push((idx, payload));
+    }
+
+    let total_count: usize = groups.values().map(|g| g.len()).sum();
+    let mut results: Vec<Option<EqlCiphertext>> = (0..total_count).map(|_| None).collect();
+
+    for (lock_context_claims, payloads) in groups {
+        let lock_context: Vec<zerokms::Context> = lock_context_claims
+            .into_iter()
+            .map(zerokms::Context::IdentityClaim)
+            .collect();
+
+        let mut prepared_plaintexts = Vec::with_capacity(payloads.len());
+        let mut original_indices = Vec::with_capacity(payloads.len());
+
+        for (original_idx, payload) in payloads {
+            let ident = Identifier::new(payload.table.clone(), payload.column.clone());
+            let column_config = client
+                .encrypt_config
+                .get(&ident)
+                .ok_or_else(|| Error::UnknownColumn(ident.clone()))?;
+
+            let index = find_index_for_type(column_config, &payload.column, &payload.index_type)?;
+            let query_op = parse_query_op(&payload.query_op)?;
+
+            let (plaintext, inferred_mode) = to_query_plaintext(
+                &payload.plaintext,
+                query_op,
+                &index.index_type,
+                column_config.cast_type,
+            )?;
+
+            let eql_operation = match inferred_mode {
+                InferredQueryMode::QueryMode(qop) => EqlOperation::Query(&index.index_type, qop),
+                InferredQueryMode::StoreMode => EqlOperation::Store,
+            };
+
+            let eql_ident = EqlIdentifier::new(&payload.table, &payload.column);
+            let prepared = PreparedPlaintext::new(
+                Cow::Borrowed(column_config),
+                eql_ident,
+                plaintext,
+                eql_operation,
+            );
+
+            prepared_plaintexts.push(prepared);
+            original_indices.push(original_idx);
+        }
+
+        let eql_opts = EqlEncryptOpts {
+            keyset_id: None,
+            lock_context: Cow::Owned(lock_context),
+            service_token: opts.service_token.as_ref().map(Cow::Borrowed),
+            unverified_context: opts.unverified_context.as_ref().map(Cow::Borrowed),
+            index_types: None,
+        };
+
+        let encrypted = encrypt_eql(client.cipher.clone(), prepared_plaintexts, &eql_opts).await?;
+
+        for (eql_ciphertext, original_idx) in encrypted.into_iter().zip(original_indices) {
+            results[original_idx] = Some(eql_ciphertext);
+        }
+    }
+
+    results
+        .into_iter()
+        .enumerate()
+        .map(|(i, opt)| {
+            opt.ok_or_else(|| {
+                Error::InvariantViolation(format!("Missing query result for index {}", i))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
+async fn decrypt_impl(client: &Client, opts: DecryptOptions) -> Result<GoPlaintext, Error> {
+    let lock_context = opts.lock_context.map(Into::into).unwrap_or_default();
+    let encrypted_record = encrypted_record_from_mp_base85(opts.ciphertext, lock_context)?;
+
+    let plaintext = client
+        .zerokms
+        .decrypt_single(
+            encrypted_record,
+            None,
+            opts.service_token.map(Cow::Owned),
+            opts.unverified_context.as_ref(),
+        )
+        .await
+        .map_err(Error::from)
+        .and_then(|bytes| Plaintext::from_slice(bytes.as_slice()).map_err(Error::from))?;
+
+    GoPlaintext::try_from(plaintext).map_err(Error::from)
+}
+
+async fn decrypt_bulk_impl(
+    client: &Client,
+    opts: DecryptBulkOptions,
+) -> Result<Vec<GoPlaintext>, Error> {
+    let ciphertexts: Vec<(Encrypted, Vec<zerokms::Context>)> = opts
+        .ciphertexts
+        .into_iter()
+        .map(|payload| {
+            let lock_context = payload.lock_context.map(Into::into).unwrap_or_default();
+            (payload.ciphertext, lock_context)
+        })
+        .collect();
+
+    let encrypted_records: Vec<WithContext<'static>> = ciphertexts
+        .into_iter()
+        .map(|(ciphertext, encryption_context)| {
+            encrypted_record_from_mp_base85(ciphertext, encryption_context)
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    let decrypted = client
+        .zerokms
+        .decrypt(
+            encrypted_records,
+            None,
+            opts.service_token.map(Cow::Owned),
+            opts.unverified_context.as_ref(),
+        )
+        .await?;
+
+    let plaintexts = decrypted
+        .into_iter()
+        .map(|bytes| Plaintext::from_slice(&bytes).and_then(GoPlaintext::try_from))
+        .collect::<Result<Vec<GoPlaintext>, TypeParseError>>()?;
+
+    Ok(plaintexts)
+}
+
+async fn decrypt_bulk_fallible_impl(
+    client: &Client,
+    opts: DecryptBulkOptions,
+) -> Result<Vec<DecryptResult>, Error> {
+    let ciphertexts: Vec<(Encrypted, Vec<zerokms::Context>)> = opts
+        .ciphertexts
+        .into_iter()
+        .map(|payload| {
+            let lock_context = payload.lock_context.map(Into::into).unwrap_or_default();
+            (payload.ciphertext, lock_context)
+        })
+        .collect();
+
+    let encrypted_records: Vec<WithContext<'static>> = ciphertexts
+        .into_iter()
+        .map(|(ciphertext, encryption_context)| {
+            encrypted_record_from_mp_base85(ciphertext, encryption_context)
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    let decrypted: Vec<Result<Vec<u8>, RecordDecryptError>> = client
+        .zerokms
+        .decrypt_fallible(
+            encrypted_records,
+            opts.service_token.map(Cow::Owned),
+            opts.unverified_context.map(Cow::Owned),
+        )
+        .await?;
+
+    let plaintexts: Vec<Result<GoPlaintext, Error>> = decrypted
+        .into_iter()
+        .map(|item: Result<Vec<u8>, RecordDecryptError>| {
+            item.map_err(Error::from).and_then(|bytes| {
+                Plaintext::from_slice(&bytes)
+                    .map_err(Error::from)
+                    .and_then(|e| GoPlaintext::try_from(e).map_err(Error::from))
+            })
+        })
+        .collect();
+
+    let results = plaintexts
+        .into_iter()
+        .map(|result| match result {
+            Ok(data) => DecryptResult::Success { data },
+            Err(err) => DecryptResult::Error {
+                error: err.to_string(),
+            },
+        })
+        .collect();
+
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Crypto helpers
+// ---------------------------------------------------------------------------
+
+fn encrypted_record_from_mp_base85(
+    encrypted: EqlCiphertext,
+    encryption_context: Vec<zerokms::Context>,
+) -> Result<WithContext<'static>, Error> {
+    let encrypted_record = encrypted.body.ciphertext.ok_or_else(|| {
+        Error::InvariantViolation("Missing ciphertext in EQL payload".to_string())
+    })?;
+
+    Ok(WithContext {
+        record: encrypted_record,
+        context: Cow::Owned(encryption_context),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Exported C FFI functions
+// ---------------------------------------------------------------------------
 
 #[no_mangle]
 pub extern "C" fn protect_new_client(options_json: *const c_char) -> CResult {
     let mut result = CResult::default();
-    
+
     let options_str = match unsafe { c_str_to_string(options_json) } {
         Ok(s) => s,
         Err(e) => {
@@ -258,51 +1199,6 @@ pub extern "C" fn protect_new_client(options_json: *const c_char) -> CResult {
     result
 }
 
-async fn new_client_impl(opts: NewClientOptions) -> Result<Client, Error> {
-    let client_opts = opts.client_opts.unwrap_or_default();
-    let console_config = ConsoleConfig::builder().with_env().build()?;
-    let cts_config = CtsConfig::builder().with_env().build()?;
-
-    let zerokms_config_builder = {
-        let mut zerokms_config_builder = ZeroKMSConfig::builder()
-            .add_source(EnvSource::default())
-            .add_source(FileSource::<CipherStashSecretConfigFile>::default().optional())
-            .add_source(FileSource::<CipherStashConfigFile>::default().optional())
-            .console_config(&console_config)
-            .cts_config(&cts_config);
-
-        if let Some(workspace_crn) = client_opts.workspace_crn {
-            zerokms_config_builder = zerokms_config_builder.workspace_crn(workspace_crn);
-        }
-
-        if let Some(access_key) = client_opts.access_key {
-            zerokms_config_builder = zerokms_config_builder.access_key(access_key);
-        }
-
-        if let Some(client_id) = client_opts.client_id {
-            zerokms_config_builder = zerokms_config_builder.try_with_client_id(&client_id)?;
-        }
-
-        if let Some(client_key) = client_opts.client_key {
-            zerokms_config_builder = zerokms_config_builder.try_with_client_key(&client_key)?;
-        }
-
-        zerokms_config_builder
-    };
-
-    let zerokms_config = zerokms_config_builder.build_with_client_key()?;
-    let zerokms = Arc::new(zerokms_config.create_client());
-    let cipher = ScopedZeroKMSNoRefresh::init(zerokms.clone(), None).await?;
-
-    let client = Client {
-        cipher: Arc::new(cipher),
-        zerokms,
-        encrypt_config: Arc::new(opts.encrypt_config.into_config_map()),
-    };
-
-    Ok(client)
-}
-
 #[no_mangle]
 pub extern "C" fn protect_encrypt(
     client_ptr: *const Client,
@@ -316,7 +1212,7 @@ pub extern "C" fn protect_encrypt(
     }
 
     let client = unsafe { &*client_ptr };
-    
+
     let options_str = match unsafe { c_str_to_string(options_json) } {
         Ok(s) => s,
         Err(e) => {
@@ -330,105 +1226,21 @@ pub extern "C" fn protect_encrypt(
         let opts: EncryptOptions = serde_json::from_str(&options_str)?;
         encrypt_impl(client, opts).await
     }) {
-        Ok(encrypted) => {
-            match serde_json::to_string(&encrypted) {
-                Ok(json) => {
-                    result.success = true;
-                    result.data = string_to_c_str(json);
-                }
-                Err(e) => {
-                    result.error = string_to_c_str(e.to_string());
-                }
+        Ok(encrypted) => match serde_json::to_string(&encrypted) {
+            Ok(json) => {
+                result.success = true;
+                result.data = string_to_c_str(json);
             }
-        }
+            Err(e) => {
+                result.error = string_to_c_str(e.to_string());
+            }
+        },
         Err(e) => {
             result.error = string_to_c_str(e.to_string());
         }
     }
 
     result
-}
-
-async fn encrypt_impl(client: &Client, opts: EncryptOptions) -> Result<Encrypted, Error> {
-    let ident = Identifier::new(opts.table, opts.column);
-
-    let column_config = client
-        .encrypt_config
-        .get(&ident)
-        .ok_or_else(|| Error::UnknownColumn(ident.clone()))?;
-
-    let mut plaintext_target = PlaintextTarget::new(opts.plaintext, column_config.clone());
-    plaintext_target.context = opts.lock_context.map(Into::into).unwrap_or_default();
-
-    let mut pipeline = ReferencedPendingPipeline::new(client.cipher.clone());
-    pipeline.add_with_ref::<PlaintextTarget>(plaintext_target, 0)?;
-
-    let mut source_encrypted = pipeline
-        .encrypt(opts.service_token, opts.unverified_context)
-        .await?;
-
-    let encrypted = source_encrypted.remove(0).ok_or_else(|| {
-        Error::InvariantViolation(
-            "`encrypt` expected a single result in the pipeline, but there were none".to_string(),
-        )
-    })?;
-
-    to_eql_encrypted(encrypted, &ident)
-}
-
-#[no_mangle]
-pub extern "C" fn protect_decrypt(
-    client_ptr: *const Client,
-    options_json: *const c_char,
-) -> CResult {
-    let mut result = CResult::default();
-
-    if client_ptr.is_null() {
-        result.error = string_to_c_str("Client pointer is null".to_string());
-        return result;
-    }
-
-    let client = unsafe { &*client_ptr };
-    
-    let options_str = match unsafe { c_str_to_string(options_json) } {
-        Ok(s) => s,
-        Err(e) => {
-            result.error = string_to_c_str(e.to_string());
-            return result;
-        }
-    };
-
-    let rt = get_runtime();
-    match rt.block_on(async {
-        let opts: DecryptOptions = serde_json::from_str(&options_str)?;
-        decrypt_impl(client, opts).await
-    }) {
-        Ok(plaintext) => {
-            result.success = true;
-            result.data = string_to_c_str(plaintext);
-        }
-        Err(e) => {
-            result.error = string_to_c_str(e.to_string());
-        }
-    }
-
-    result
-}
-
-async fn decrypt_impl(client: &Client, opts: DecryptOptions) -> Result<String, Error> {
-    let lock_context = opts.lock_context.map(Into::into).unwrap_or_default();
-    let encrypted_record = encrypted_record_from_mp_base85(&opts.ciphertext, lock_context)?;
-
-    let decrypted = client
-        .zerokms
-        .decrypt_single(
-            encrypted_record,
-            opts.service_token,
-            opts.unverified_context,
-        )
-        .await?;
-
-    plaintext_str_from_bytes(decrypted)
 }
 
 #[no_mangle]
@@ -444,7 +1256,7 @@ pub extern "C" fn protect_encrypt_bulk(
     }
 
     let client = unsafe { &*client_ptr };
-    
+
     let options_str = match unsafe { c_str_to_string(options_json) } {
         Ok(s) => s,
         Err(e) => {
@@ -458,17 +1270,15 @@ pub extern "C" fn protect_encrypt_bulk(
         let opts: EncryptBulkOptions = serde_json::from_str(&options_str)?;
         encrypt_bulk_impl(client, opts).await
     }) {
-        Ok(encrypted_list) => {
-            match serde_json::to_string(&encrypted_list) {
-                Ok(json) => {
-                    result.success = true;
-                    result.data = string_to_c_str(json);
-                }
-                Err(e) => {
-                    result.error = string_to_c_str(e.to_string());
-                }
+        Ok(encrypted_list) => match serde_json::to_string(&encrypted_list) {
+            Ok(json) => {
+                result.success = true;
+                result.data = string_to_c_str(json);
             }
-        }
+            Err(e) => {
+                result.error = string_to_c_str(e.to_string());
+            }
+        },
         Err(e) => {
             result.error = string_to_c_str(e.to_string());
         }
@@ -477,59 +1287,136 @@ pub extern "C" fn protect_encrypt_bulk(
     result
 }
 
-async fn encrypt_bulk_impl(client: &Client, opts: EncryptBulkOptions) -> Result<Vec<Encrypted>, Error> {
-    let plaintext_targets = opts
-        .plaintexts
-        .into_iter()
-        .map(|payload| {
-            let ident = Identifier::new(payload.table, payload.column);
+#[no_mangle]
+pub extern "C" fn protect_encrypt_query(
+    client_ptr: *const Client,
+    options_json: *const c_char,
+) -> CResult {
+    let mut result = CResult::default();
 
-            let column_config = client
-                .encrypt_config
-                .get(&ident)
-                .ok_or_else(|| Error::UnknownColumn(ident.clone()))?;
-
-            let mut plaintext_target =
-                PlaintextTarget::new(payload.plaintext, column_config.clone());
-            plaintext_target.context = payload.lock_context.map(Into::into).unwrap_or_default();
-
-            Ok((plaintext_target, ident))
-        })
-        .collect::<Result<Vec<(PlaintextTarget, Identifier)>, Error>>()?;
-
-    let len = plaintext_targets.len();
-    let mut pipeline = ReferencedPendingPipeline::new(client.cipher.clone());
-    let (plaintext_targets, identifiers): (Vec<PlaintextTarget>, Vec<Identifier>) =
-        plaintext_targets.into_iter().unzip();
-
-    for (i, plaintext_target) in plaintext_targets.into_iter().enumerate() {
-        pipeline.add_with_ref::<PlaintextTarget>(plaintext_target, i)?;
+    if client_ptr.is_null() {
+        result.error = string_to_c_str("Client pointer is null".to_string());
+        return result;
     }
 
-    let mut source_encrypted = pipeline
-        .encrypt(opts.service_token, opts.unverified_context)
-        .await?;
+    let client = unsafe { &*client_ptr };
 
-    let mut results: Vec<Encrypted> = Vec::with_capacity(len);
+    let options_str = match unsafe { c_str_to_string(options_json) } {
+        Ok(s) => s,
+        Err(e) => {
+            result.error = string_to_c_str(e.to_string());
+            return result;
+        }
+    };
 
-    for i in 0..len {
-        let encrypted = source_encrypted.remove(i).ok_or_else(|| {
-            Error::InvariantViolation(format!(
-                "`encrypt_bulk` expected a result in the pipeline at index {i}, but there was none"
-            ))
-        })?;
-
-        let ident = identifiers.get(i).ok_or_else(|| {
-            Error::InvariantViolation(format!(
-                "`encrypt_bulk` expected an identifier to exist for index {i}, but there was none"
-            ))
-        })?;
-
-        let eql_payload = to_eql_encrypted(encrypted, ident)?;
-        results.push(eql_payload);
+    let rt = get_runtime();
+    match rt.block_on(async {
+        let opts: EncryptQueryOptions = serde_json::from_str(&options_str)?;
+        encrypt_query_impl(client, opts).await
+    }) {
+        Ok(encrypted) => match serde_json::to_string(&encrypted) {
+            Ok(json) => {
+                result.success = true;
+                result.data = string_to_c_str(json);
+            }
+            Err(e) => {
+                result.error = string_to_c_str(e.to_string());
+            }
+        },
+        Err(e) => {
+            result.error = string_to_c_str(e.to_string());
+        }
     }
 
-    Ok(results)
+    result
+}
+
+#[no_mangle]
+pub extern "C" fn protect_encrypt_query_bulk(
+    client_ptr: *const Client,
+    options_json: *const c_char,
+) -> CResult {
+    let mut result = CResult::default();
+
+    if client_ptr.is_null() {
+        result.error = string_to_c_str("Client pointer is null".to_string());
+        return result;
+    }
+
+    let client = unsafe { &*client_ptr };
+
+    let options_str = match unsafe { c_str_to_string(options_json) } {
+        Ok(s) => s,
+        Err(e) => {
+            result.error = string_to_c_str(e.to_string());
+            return result;
+        }
+    };
+
+    let rt = get_runtime();
+    match rt.block_on(async {
+        let opts: EncryptQueryBulkOptions = serde_json::from_str(&options_str)?;
+        encrypt_query_bulk_impl(client, opts).await
+    }) {
+        Ok(encrypted_list) => match serde_json::to_string(&encrypted_list) {
+            Ok(json) => {
+                result.success = true;
+                result.data = string_to_c_str(json);
+            }
+            Err(e) => {
+                result.error = string_to_c_str(e.to_string());
+            }
+        },
+        Err(e) => {
+            result.error = string_to_c_str(e.to_string());
+        }
+    }
+
+    result
+}
+
+#[no_mangle]
+pub extern "C" fn protect_decrypt(
+    client_ptr: *const Client,
+    options_json: *const c_char,
+) -> CResult {
+    let mut result = CResult::default();
+
+    if client_ptr.is_null() {
+        result.error = string_to_c_str("Client pointer is null".to_string());
+        return result;
+    }
+
+    let client = unsafe { &*client_ptr };
+
+    let options_str = match unsafe { c_str_to_string(options_json) } {
+        Ok(s) => s,
+        Err(e) => {
+            result.error = string_to_c_str(e.to_string());
+            return result;
+        }
+    };
+
+    let rt = get_runtime();
+    match rt.block_on(async {
+        let opts: DecryptOptions = serde_json::from_str(&options_str)?;
+        decrypt_impl(client, opts).await
+    }) {
+        Ok(plaintext) => match serde_json::to_string(&plaintext) {
+            Ok(json) => {
+                result.success = true;
+                result.data = string_to_c_str(json);
+            }
+            Err(e) => {
+                result.error = string_to_c_str(e.to_string());
+            }
+        },
+        Err(e) => {
+            result.error = string_to_c_str(e.to_string());
+        }
+    }
+
+    result
 }
 
 #[no_mangle]
@@ -545,7 +1432,7 @@ pub extern "C" fn protect_decrypt_bulk(
     }
 
     let client = unsafe { &*client_ptr };
-    
+
     let options_str = match unsafe { c_str_to_string(options_json) } {
         Ok(s) => s,
         Err(e) => {
@@ -559,57 +1446,21 @@ pub extern "C" fn protect_decrypt_bulk(
         let opts: DecryptBulkOptions = serde_json::from_str(&options_str)?;
         decrypt_bulk_impl(client, opts).await
     }) {
-        Ok(plaintexts) => {
-            match serde_json::to_string(&plaintexts) {
-                Ok(json) => {
-                    result.success = true;
-                    result.data = string_to_c_str(json);
-                }
-                Err(e) => {
-                    result.error = string_to_c_str(e.to_string());
-                }
+        Ok(plaintexts) => match serde_json::to_string(&plaintexts) {
+            Ok(json) => {
+                result.success = true;
+                result.data = string_to_c_str(json);
             }
-        }
+            Err(e) => {
+                result.error = string_to_c_str(e.to_string());
+            }
+        },
         Err(e) => {
             result.error = string_to_c_str(e.to_string());
         }
     }
 
     result
-}
-
-async fn decrypt_bulk_impl(client: &Client, opts: DecryptBulkOptions) -> Result<Vec<String>, Error> {
-    let ciphertexts: Vec<(String, Vec<zerokms::Context>)> = opts
-        .ciphertexts
-        .into_iter()
-        .map(|payload| {
-            let lock_context = payload.lock_context.map(Into::into).unwrap_or_default();
-            (payload.ciphertext, lock_context)
-        })
-        .collect();
-
-    let encrypted_records = ciphertexts
-        .into_iter()
-        .map(|(ciphertext, encryption_context)| {
-            encrypted_record_from_mp_base85(&ciphertext, encryption_context)
-        })
-        .collect::<Result<Vec<WithContext>, Error>>()?;
-
-    let decrypted = client
-        .zerokms
-        .decrypt(
-            encrypted_records,
-            opts.service_token,
-            opts.unverified_context,
-        )
-        .await?;
-
-    let plaintexts = decrypted
-        .into_iter()
-        .map(plaintext_str_from_bytes)
-        .collect::<Result<Vec<String>, Error>>()?;
-
-    Ok(plaintexts)
 }
 
 #[no_mangle]
@@ -625,7 +1476,7 @@ pub extern "C" fn protect_decrypt_bulk_fallible(
     }
 
     let client = unsafe { &*client_ptr };
-    
+
     let options_str = match unsafe { c_str_to_string(options_json) } {
         Ok(s) => s,
         Err(e) => {
@@ -639,17 +1490,15 @@ pub extern "C" fn protect_decrypt_bulk_fallible(
         let opts: DecryptBulkOptions = serde_json::from_str(&options_str)?;
         decrypt_bulk_fallible_impl(client, opts).await
     }) {
-        Ok(results) => {
-            match serde_json::to_string(&results) {
-                Ok(json) => {
-                    result.success = true;
-                    result.data = string_to_c_str(json);
-                }
-                Err(e) => {
-                    result.error = string_to_c_str(e.to_string());
-                }
+        Ok(results_vec) => match serde_json::to_string(&results_vec) {
+            Ok(json) => {
+                result.success = true;
+                result.data = string_to_c_str(json);
             }
-        }
+            Err(e) => {
+                result.error = string_to_c_str(e.to_string());
+            }
+        },
         Err(e) => {
             result.error = string_to_c_str(e.to_string());
         }
@@ -658,50 +1507,15 @@ pub extern "C" fn protect_decrypt_bulk_fallible(
     result
 }
 
-async fn decrypt_bulk_fallible_impl(client: &Client, opts: DecryptBulkOptions) -> Result<Vec<DecryptResult>, Error> {
-    let ciphertexts: Vec<(String, Vec<zerokms::Context>)> = opts
-        .ciphertexts
-        .into_iter()
-        .map(|payload| {
-            let lock_context = payload.lock_context.map(Into::into).unwrap_or_default();
-            (payload.ciphertext, lock_context)
-        })
-        .collect();
-
-    let encrypted_records: Result<Vec<WithContext>, Error> = ciphertexts
-        .into_iter()
-        .map(|(ciphertext, encryption_context)| {
-            encrypted_record_from_mp_base85(&ciphertext, encryption_context)
-        })
-        .collect();
-
-    let encrypted_records = encrypted_records?;
-
-    let decrypted = client
-        .zerokms
-        .decrypt_fallible(
-            encrypted_records,
-            opts.service_token,
-            opts.unverified_context,
-        )
-        .await?;
-
-    let plaintexts: Vec<Result<String, Error>> = decrypted
-        .into_iter()
-        .map(|item| item.map_err(Error::from).and_then(plaintext_str_from_bytes))
-        .collect();
-
-    let results = plaintexts
-        .into_iter()
-        .map(|result| match result {
-            Ok(data) => DecryptResult::Success { data },
-            Err(err) => DecryptResult::Error {
-                error: err.to_string(),
-            },
-        })
-        .collect();
-
-    Ok(results)
+/// Check if a JSON value is a valid EQL ciphertext.
+#[no_mangle]
+pub extern "C" fn protect_is_encrypted(value_json: *const c_char) -> bool {
+    let value_str = match unsafe { c_str_to_string(value_json) } {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let result: Result<EqlCiphertext, _> = serde_json::from_str(&value_str);
+    result.is_ok()
 }
 
 #[no_mangle]
@@ -722,105 +1536,586 @@ pub extern "C" fn protect_free_string(str_ptr: *const c_char) {
     }
 }
 
-// Helper functions (same as original)
-fn encrypted_record_from_mp_base85(
-    base85str: &str,
-    encryption_context: Vec<zerokms::Context>,
-) -> Result<WithContext, Error> {
-    let encrypted_record = EncryptedRecord::from_mp_base85(base85str)
-        .map_err(|err| Error::Base85(err.to_string()))?;
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
-    Ok(WithContext {
-        record: encrypted_record,
-        context: encryption_context,
-    })
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-fn plaintext_str_from_bytes(bytes: Vec<u8>) -> Result<String, Error> {
-    let plaintext = Plaintext::from_slice(bytes.as_slice())?;
+    mod truncate_for_error_tests {
+        use super::*;
 
-    match plaintext {
-        Plaintext::Utf8Str(Some(ref inner)) => Ok(inner.clone()),
-        _ => Err(Error::Unimplemented(
-            "data types other than `Utf8Str`".to_string(),
-        )),
+        #[test]
+        fn handles_non_ascii_without_panicking() {
+            let input = "\u{e9}\u{e9}\u{e9}";
+            assert_eq!(truncate_for_error(input, 1), "\u{e9}...");
+        }
+
+        #[test]
+        fn returns_ellipsis_when_max_len_zero() {
+            assert_eq!(truncate_for_error("abc", 0), "...");
+        }
+
+        #[test]
+        fn returns_full_string_when_within_limit() {
+            assert_eq!(truncate_for_error("abc", 5), "abc");
+        }
+
+        #[test]
+        fn returns_full_string_when_at_limit() {
+            assert_eq!(truncate_for_error("abc", 3), "abc");
+        }
+
+        #[test]
+        fn truncates_when_over_limit() {
+            assert_eq!(truncate_for_error("abcdef", 3), "abc...");
+        }
     }
-}
 
-fn to_eql_encrypted(
-    encrypted: encryption::Encrypted,
-    identifier: &Identifier,
-) -> Result<Encrypted, Error> {
-    match encrypted {
-        encryption::Encrypted::Record(ciphertext, terms) => {
-            struct Indexes {
-                match_index: Option<Vec<u16>>,
-                ore_index: Option<Vec<String>>,
-                unique_index: Option<String>,
+    mod is_encrypted_tests {
+        use super::*;
+        use serde_json::json;
+        use std::ffi::CString;
+
+        fn check_is_encrypted(value: serde_json::Value) -> bool {
+            let json_str = serde_json::to_string(&value).unwrap();
+            let c_str = CString::new(json_str).unwrap();
+            protect_is_encrypted(c_str.as_ptr())
+        }
+
+        #[test]
+        fn valid_eql_ciphertext_is_encrypted() {
+            let valid = json!({
+                "i": {"t": "users", "c": "email"},
+                "v": 2
+            });
+            assert!(check_is_encrypted(valid));
+        }
+
+        #[test]
+        fn valid_eql_ciphertext_with_ste_vec_is_encrypted() {
+            let valid = json!({
+                "i": {"t": "users", "c": "profile"},
+                "v": 2,
+                "sv": [{"s": "deadbeef"}]
+            });
+            assert!(check_is_encrypted(valid));
+        }
+
+        #[test]
+        fn invalid_ciphertext_is_not_encrypted() {
+            let invalid = json!({"random": "data"});
+            assert!(!check_is_encrypted(invalid));
+        }
+
+        #[test]
+        fn old_format_with_k_field_is_still_valid() {
+            let old_format = json!({
+                "k": "ct",
+                "i": {"t": "users", "c": "email"},
+                "v": 2
+            });
+            assert!(check_is_encrypted(old_format));
+        }
+
+        #[test]
+        fn old_ste_vec_format_with_k_field_is_still_valid() {
+            let old_format = json!({
+                "k": "sv",
+                "i": {"t": "users", "c": "profile"},
+                "v": 2
+            });
+            assert!(check_is_encrypted(old_format));
+        }
+    }
+
+    mod lock_context_grouping {
+        use std::collections::BTreeMap;
+
+        fn group_by_lock_context(
+            payloads: Vec<(String, Option<Vec<String>>)>,
+        ) -> BTreeMap<Vec<String>, Vec<(usize, String)>> {
+            let mut groups: BTreeMap<Vec<String>, Vec<(usize, String)>> = BTreeMap::new();
+            for (idx, (data, lock_context)) in payloads.into_iter().enumerate() {
+                let key = lock_context.unwrap_or_default();
+                groups.entry(key).or_default().push((idx, data));
             }
+            groups
+        }
 
-            let mut indexes = Indexes {
-                match_index: None,
-                ore_index: None,
-                unique_index: None,
+        #[test]
+        fn same_lock_context_groups_together() {
+            let payloads = vec![
+                ("a".to_string(), Some(vec!["user:1".to_string()])),
+                ("b".to_string(), Some(vec!["user:1".to_string()])),
+                ("c".to_string(), Some(vec!["user:1".to_string()])),
+            ];
+
+            let groups = group_by_lock_context(payloads);
+
+            assert_eq!(groups.len(), 1);
+            assert_eq!(groups[&vec!["user:1".to_string()]].len(), 3);
+        }
+
+        #[test]
+        fn different_lock_contexts_separate_groups() {
+            let payloads = vec![
+                ("a".to_string(), Some(vec!["user:1".to_string()])),
+                ("b".to_string(), Some(vec!["user:2".to_string()])),
+                ("c".to_string(), Some(vec!["user:1".to_string()])),
+            ];
+
+            let groups = group_by_lock_context(payloads);
+
+            assert_eq!(groups.len(), 2);
+            assert_eq!(groups[&vec!["user:1".to_string()]].len(), 2);
+            assert_eq!(groups[&vec!["user:2".to_string()]].len(), 1);
+        }
+
+        #[test]
+        fn none_lock_context_groups_together() {
+            let payloads = vec![
+                ("a".to_string(), None),
+                ("b".to_string(), None),
+                ("c".to_string(), Some(vec!["user:1".to_string()])),
+            ];
+
+            let groups = group_by_lock_context(payloads);
+
+            assert_eq!(groups.len(), 2);
+            assert_eq!(groups[&vec![]].len(), 2);
+            assert_eq!(groups[&vec!["user:1".to_string()]].len(), 1);
+        }
+
+        #[test]
+        fn preserves_original_indices() {
+            let payloads = vec![
+                ("a".to_string(), Some(vec!["user:2".to_string()])),
+                ("b".to_string(), Some(vec!["user:1".to_string()])),
+                ("c".to_string(), Some(vec!["user:2".to_string()])),
+            ];
+
+            let groups = group_by_lock_context(payloads);
+
+            let user1_group = &groups[&vec!["user:1".to_string()]];
+            assert_eq!(user1_group[0], (1, "b".to_string()));
+
+            let user2_group = &groups[&vec!["user:2".to_string()]];
+            assert_eq!(user2_group[0], (0, "a".to_string()));
+            assert_eq!(user2_group[1], (2, "c".to_string()));
+        }
+    }
+
+    mod query_op_parsing {
+        use super::*;
+
+        #[test]
+        fn parse_query_op_default() {
+            let result = parse_query_op("default");
+            assert!(matches!(result, Ok(QueryOp::Default)));
+        }
+
+        #[test]
+        fn parse_query_op_ste_vec_selector() {
+            let result = parse_query_op("ste_vec_selector");
+            assert!(matches!(result, Ok(QueryOp::SteVecSelector)));
+        }
+
+        #[test]
+        fn parse_query_op_ste_vec_term() {
+            let result = parse_query_op("ste_vec_term");
+            assert!(matches!(result, Ok(QueryOp::SteVecTerm)));
+        }
+
+        #[test]
+        fn parse_query_op_unknown_returns_error() {
+            let result = parse_query_op("unknown");
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert!(err.to_string().contains("Unknown query operation"));
+        }
+    }
+
+    mod find_index_for_type_tests {
+        use super::*;
+        use cipherstash_client::schema::column::{Index, IndexType, Tokenizer};
+
+        fn make_column_config_with_indexes(indexes: Vec<Index>) -> ColumnConfig {
+            ColumnConfig {
+                name: "test_column".to_string(),
+                cast_type: cipherstash_client::schema::column::ColumnType::Utf8Str,
+                indexes,
+                in_place: false,
+                mode: cipherstash_client::schema::column::ColumnMode::Encrypted,
+            }
+        }
+
+        #[test]
+        fn find_ste_vec_index() {
+            let config = make_column_config_with_indexes(vec![Index::new(IndexType::SteVec {
+                prefix: "test".to_string(),
+                term_filters: vec![],
+                array_index_mode: Default::default(),
+            })]);
+            let result = find_index_for_type(&config, "test_column", "ste_vec");
+            assert!(result.is_ok());
+            assert!(matches!(
+                result.unwrap().index_type,
+                IndexType::SteVec { .. }
+            ));
+        }
+
+        #[test]
+        fn find_ore_index() {
+            let config = make_column_config_with_indexes(vec![Index::new(IndexType::Ore)]);
+            let result = find_index_for_type(&config, "test_column", "ore");
+            assert!(result.is_ok());
+            assert!(matches!(result.unwrap().index_type, IndexType::Ore));
+        }
+
+        #[test]
+        fn find_unique_index() {
+            let config = make_column_config_with_indexes(vec![Index::new(IndexType::Unique {
+                token_filters: vec![],
+            })]);
+            let result = find_index_for_type(&config, "test_column", "unique");
+            assert!(result.is_ok());
+            assert!(matches!(
+                result.unwrap().index_type,
+                IndexType::Unique { .. }
+            ));
+        }
+
+        #[test]
+        fn find_match_index() {
+            let config = make_column_config_with_indexes(vec![Index::new(IndexType::Match {
+                tokenizer: Tokenizer::Standard,
+                token_filters: vec![],
+                k: 3,
+                m: 2048,
+                include_original: false,
+            })]);
+            let result = find_index_for_type(&config, "test_column", "match");
+            assert!(result.is_ok());
+            assert!(matches!(
+                result.unwrap().index_type,
+                IndexType::Match { .. }
+            ));
+        }
+
+        #[test]
+        fn missing_index_returns_error() {
+            let config = make_column_config_with_indexes(vec![Index::new(IndexType::Ore)]);
+            let result = find_index_for_type(&config, "test_column", "ste_vec");
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert!(err.to_string().contains("does not have"));
+            assert!(err.to_string().contains("test_column"));
+        }
+
+        #[test]
+        fn unknown_index_type_returns_error() {
+            let config = make_column_config_with_indexes(vec![Index::new(IndexType::Ore)]);
+            let result = find_index_for_type(&config, "test_column", "invalid_type");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn missing_index_error_includes_column_and_suggestions() {
+            let config = make_column_config_with_indexes(vec![
+                Index::new(IndexType::Ore),
+                Index::new(IndexType::Match {
+                    tokenizer: Tokenizer::Standard,
+                    token_filters: vec![],
+                    k: 6,
+                    m: 2048,
+                    include_original: false,
+                }),
+            ]);
+            let result = find_index_for_type(&config, "email", "ste_vec");
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err().to_string();
+            assert!(
+                err_msg.contains("email"),
+                "Error should include column name: {}",
+                err_msg
+            );
+            assert!(
+                err_msg.contains("ste_vec"),
+                "Error should include requested index type: {}",
+                err_msg
+            );
+            assert!(
+                err_msg.contains("ore"),
+                "Error should show available ore index: {}",
+                err_msg
+            );
+            assert!(
+                err_msg.contains("match"),
+                "Error should show available match index: {}",
+                err_msg
+            );
+        }
+    }
+
+    mod query_inference_tests {
+        use super::*;
+        use cipherstash_client::encryption::Plaintext;
+        use cipherstash_client::schema::column::Tokenizer;
+        use cipherstash_client::schema::column::{ColumnType, IndexType};
+
+        #[test]
+        fn test_ste_vec_default_with_string_infers_selector() {
+            let go_plaintext = GoPlaintext::String("$.user.email".to_string());
+            let index_type = IndexType::SteVec {
+                prefix: "test/col".to_string(),
+                term_filters: vec![],
+                array_index_mode: Default::default(),
             };
 
-            for index_term in terms {
-                match index_term {
-                    IndexTerm::Binary(bytes) => {
-                        indexes.unique_index = Some(format_index_term_binary(&bytes))
-                    }
-                    IndexTerm::BitMap(inner) => indexes.match_index = Some(inner),
-                    IndexTerm::OreArray(vec_of_bytes) => {
-                        indexes.ore_index = Some(format_index_term_ore_array(&vec_of_bytes));
-                    }
-                    IndexTerm::OreFull(bytes) => {
-                        indexes.ore_index = Some(format_index_term_ore(&bytes));
-                    }
-                    IndexTerm::OreLeft(bytes) => {
-                        indexes.ore_index = Some(format_index_term_ore(&bytes));
-                    }
-                    IndexTerm::Null => {}
-                    term => return Err(Error::Unimplemented(format!("index term `{term:?}`"))),
-                };
-            }
+            let result = to_query_plaintext(
+                &go_plaintext,
+                QueryOp::Default,
+                &index_type,
+                ColumnType::JsonB,
+            );
 
-            let ciphertext = ciphertext
-                .to_mp_base85()
-                .map_err(|err| Error::Base85(err.to_string()))?;
-
-            Ok(Encrypted::Ciphertext {
-                ciphertext,
-                identifier: identifier.to_owned(),
-                match_index: indexes.match_index,
-                ore_index: indexes.ore_index,
-                unique_index: indexes.unique_index,
-                version: 2,
-            })
+            assert!(matches!(
+                result,
+                Ok((
+                    Plaintext::Utf8Str(Some(_)),
+                    InferredQueryMode::QueryMode(QueryOp::SteVecSelector)
+                ))
+            ));
         }
-        encryption::Encrypted::SteVec(ste_vec_index) => Ok(Encrypted::SteVec {
-            identifier: identifier.to_owned(),
-            ste_vec_index,
-            version: 2,
-        }),
+
+        #[test]
+        fn test_ste_vec_default_with_object_infers_store_mode() {
+            let go_plaintext = GoPlaintext::JsonB(serde_json::json!({"role": "admin"}));
+            let index_type = IndexType::SteVec {
+                prefix: "test/col".to_string(),
+                term_filters: vec![],
+                array_index_mode: Default::default(),
+            };
+
+            let result = to_query_plaintext(
+                &go_plaintext,
+                QueryOp::Default,
+                &index_type,
+                ColumnType::JsonB,
+            );
+
+            assert!(matches!(
+                result,
+                Ok((Plaintext::JsonB(Some(_)), InferredQueryMode::StoreMode))
+            ));
+        }
+
+        #[test]
+        fn test_ste_vec_default_with_array_infers_store_mode() {
+            let go_plaintext = GoPlaintext::JsonB(serde_json::json!(["admin", "user"]));
+            let index_type = IndexType::SteVec {
+                prefix: "test/col".to_string(),
+                term_filters: vec![],
+                array_index_mode: Default::default(),
+            };
+
+            let result = to_query_plaintext(
+                &go_plaintext,
+                QueryOp::Default,
+                &index_type,
+                ColumnType::JsonB,
+            );
+
+            assert!(matches!(
+                result,
+                Ok((Plaintext::JsonB(Some(_)), InferredQueryMode::StoreMode))
+            ));
+        }
+
+        #[test]
+        fn test_ste_vec_default_with_number_returns_error() {
+            let go_plaintext = GoPlaintext::Number(42.0);
+            let index_type = IndexType::SteVec {
+                prefix: "test/col".to_string(),
+                term_filters: vec![],
+                array_index_mode: Default::default(),
+            };
+
+            let result = to_query_plaintext(
+                &go_plaintext,
+                QueryOp::Default,
+                &index_type,
+                ColumnType::JsonB,
+            );
+
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err().to_string();
+            assert!(
+                err_msg.contains("Invalid query input"),
+                "Error message should mention invalid input: {}",
+                err_msg
+            );
+        }
+
+        #[test]
+        fn test_ste_vec_default_with_boolean_returns_error() {
+            let go_plaintext = GoPlaintext::Boolean(true);
+            let index_type = IndexType::SteVec {
+                prefix: "test/col".to_string(),
+                term_filters: vec![],
+                array_index_mode: Default::default(),
+            };
+
+            let result = to_query_plaintext(
+                &go_plaintext,
+                QueryOp::Default,
+                &index_type,
+                ColumnType::JsonB,
+            );
+
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn test_explicit_ste_vec_selector_uses_query_mode() {
+            let go_plaintext = GoPlaintext::String("$.name".to_string());
+            let index_type = IndexType::SteVec {
+                prefix: "test/col".to_string(),
+                term_filters: vec![],
+                array_index_mode: Default::default(),
+            };
+
+            let result = to_query_plaintext(
+                &go_plaintext,
+                QueryOp::SteVecSelector,
+                &index_type,
+                ColumnType::JsonB,
+            );
+
+            assert!(matches!(
+                result,
+                Ok((
+                    Plaintext::Utf8Str(Some(_)),
+                    InferredQueryMode::QueryMode(QueryOp::SteVecSelector)
+                ))
+            ));
+        }
+
+        #[test]
+        fn test_explicit_ste_vec_term_uses_store_mode() {
+            let go_plaintext = GoPlaintext::JsonB(serde_json::json!({"key": "value"}));
+            let index_type = IndexType::SteVec {
+                prefix: "test/col".to_string(),
+                term_filters: vec![],
+                array_index_mode: Default::default(),
+            };
+
+            let result = to_query_plaintext(
+                &go_plaintext,
+                QueryOp::SteVecTerm,
+                &index_type,
+                ColumnType::JsonB,
+            );
+
+            assert!(matches!(
+                result,
+                Ok((Plaintext::JsonB(Some(_)), InferredQueryMode::StoreMode))
+            ));
+        }
+
+        #[test]
+        fn test_non_ste_vec_default_uses_column_type() {
+            let go_plaintext = GoPlaintext::String("search term".to_string());
+            let index_type = IndexType::Match {
+                tokenizer: Tokenizer::Standard,
+                token_filters: vec![],
+                k: 6,
+                m: 2048,
+                include_original: true,
+            };
+
+            let result = to_query_plaintext(
+                &go_plaintext,
+                QueryOp::Default,
+                &index_type,
+                ColumnType::Utf8Str,
+            );
+
+            assert!(matches!(
+                result,
+                Ok((
+                    Plaintext::Utf8Str(Some(_)),
+                    InferredQueryMode::QueryMode(QueryOp::Default)
+                ))
+            ));
+        }
+
+        #[test]
+        fn test_ste_vec_term_with_string_error_is_helpful() {
+            let go_plaintext = GoPlaintext::String("admin".to_string());
+            let index_type = IndexType::SteVec {
+                prefix: "test/col".to_string(),
+                term_filters: vec![],
+                array_index_mode: Default::default(),
+            };
+
+            let result = to_query_plaintext(
+                &go_plaintext,
+                QueryOp::SteVecTerm,
+                &index_type,
+                ColumnType::JsonB,
+            );
+
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err().to_string();
+            assert!(
+                err_msg.contains("ste_vec_term"),
+                "Error should mention ste_vec_term: {}",
+                err_msg
+            );
+            assert!(
+                err_msg.contains("String"),
+                "Error should mention received String: {}",
+                err_msg
+            );
+            assert!(
+                err_msg.contains("ste_vec_selector") || err_msg.contains("path"),
+                "Error should suggest ste_vec_selector for paths: {}",
+                err_msg
+            );
+        }
+
+        #[test]
+        fn test_invalid_json_path_error() {
+            let go_plaintext = GoPlaintext::String("user.email".to_string());
+            let index_type = IndexType::SteVec {
+                prefix: "test/col".to_string(),
+                term_filters: vec![],
+                array_index_mode: Default::default(),
+            };
+
+            let result = to_query_plaintext(
+                &go_plaintext,
+                QueryOp::SteVecSelector,
+                &index_type,
+                ColumnType::JsonB,
+            );
+
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err().to_string();
+            assert!(
+                err_msg.contains("user.email"),
+                "Error should show the invalid path: {}",
+                err_msg
+            );
+            assert!(
+                err_msg.contains("$.user.email") || err_msg.contains("$"),
+                "Error should suggest correct format with $: {}",
+                err_msg
+            );
+        }
     }
 }
-
-fn format_index_term_binary(bytes: &Vec<u8>) -> String {
-    hex::encode(bytes)
-}
-
-fn format_index_term_ore_bytea(bytes: &Vec<u8>) -> String {
-    hex::encode(bytes)
-}
-
-fn format_index_term_ore_array(vec_of_bytes: &[Vec<u8>]) -> Vec<String> {
-    vec_of_bytes
-        .iter()
-        .map(format_index_term_ore_bytea)
-        .collect()
-}
-
-fn format_index_term_ore(bytes: &Vec<u8>) -> Vec<String> {
-    vec![format_index_term_ore_bytea(bytes)]
-} 

--- a/examples/basic_usage.go
+++ b/examples/basic_usage.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -8,7 +10,7 @@ import (
 	"github.com/cipherstash/protectgo/pkg/protect"
 )
 
-// Define your data model with encryption schema using struct tags.
+// User defines the data model with encryption schema using struct tags.
 //
 // The `cs` tag defines:
 //   - Column name (first value)
@@ -27,42 +29,49 @@ type User struct {
 }
 
 func main() {
+	ctx := context.Background()
+
 	// ---------------------------------------------------------------
-	// 1. Define schema from struct tags and create client
+	// 1. Define schema from struct tags
 	// ---------------------------------------------------------------
 
-	config := protect.BuildEncryptConfig(
-		protect.TableSchema("users", User{}),
+	users, err := protect.TableSchema("users", User{})
+	if err != nil {
+		log.Fatalf("Failed to create schema: %v", err)
+	}
+
+	// ---------------------------------------------------------------
+	// 2. Create client with functional options
+	// ---------------------------------------------------------------
+
+	client, err := protect.NewClient(ctx,
+		protect.WithSchemas(users),
+		protect.WithCredentials(
+			os.Getenv("CS_WORKSPACE_CRN"),
+			os.Getenv("CS_CLIENT_ACCESS_KEY"),
+			os.Getenv("CS_CLIENT_ID"),
+			os.Getenv("CS_CLIENT_KEY"),
+		),
 	)
-
-	client, err := protect.NewClient(protect.NewClientOptions{
-		EncryptConfig: config,
-		ClientOpts: &protect.ClientOpts{
-			WorkspaceCrn: ptr(os.Getenv("CS_WORKSPACE_CRN")),
-			AccessKey:    ptr(os.Getenv("CS_CLIENT_ACCESS_KEY")),
-			ClientID:     ptr(os.Getenv("CS_CLIENT_ID")),
-			ClientKey:    ptr(os.Getenv("CS_CLIENT_KEY")),
-		},
-	})
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}
-	defer client.Free()
+	defer client.Close()
 
 	// ---------------------------------------------------------------
-	// 2. Encrypt and decrypt a model (struct-based)
+	// 3. Encrypt and decrypt a model (struct-based)
 	// ---------------------------------------------------------------
 
 	user := User{
-		ID:    1,
-		Email: "john.doe@example.com",
-		Name:  "John Doe",
-		Age:   30,
+		ID:     1,
+		Email:  "john.doe@example.com",
+		Name:   "John Doe",
+		Age:    30,
 		Active: true,
-		Role:  "admin",
+		Role:   "admin",
 	}
 
-	encryptedMap, err := client.EncryptModel(user, "users")
+	encryptedMap, err := client.EncryptModel(ctx, users, user)
 	if err != nil {
 		log.Fatalf("Failed to encrypt model: %v", err)
 	}
@@ -76,7 +85,7 @@ func main() {
 	fmt.Printf("  active:        [encrypted]\n")
 
 	var decryptedUser User
-	err = client.DecryptModel(encryptedMap, "users", &decryptedUser)
+	err = client.DecryptModel(ctx, users, encryptedMap, &decryptedUser)
 	if err != nil {
 		log.Fatalf("Failed to decrypt model: %v", err)
 	}
@@ -88,15 +97,15 @@ func main() {
 	fmt.Printf("  Role:  %s\n", decryptedUser.Role)
 
 	// ---------------------------------------------------------------
-	// 3. Bulk encrypt and decrypt models (single KMS call)
+	// 4. Bulk encrypt and decrypt models (single KMS call)
 	// ---------------------------------------------------------------
 
-	users := []User{
+	userSlice := []User{
 		{ID: 1, Email: "alice@example.com", Name: "Alice", Age: 28, Active: true, Role: "admin"},
 		{ID: 2, Email: "bob@example.com", Name: "Bob", Age: 35, Active: false, Role: "user"},
 	}
 
-	encryptedModels, err := client.BulkEncryptModels(users, "users")
+	encryptedModels, err := client.BulkEncryptModels(ctx, users, userSlice)
 	if err != nil {
 		log.Fatalf("Failed to bulk encrypt models: %v", err)
 	}
@@ -104,7 +113,7 @@ func main() {
 	fmt.Printf("\nBulk encrypted %d models\n", len(encryptedModels))
 
 	var decryptedUsers []User
-	err = client.BulkDecryptModels(encryptedModels, "users", &decryptedUsers)
+	err = client.BulkDecryptModels(ctx, users, encryptedModels, &decryptedUsers)
 	if err != nil {
 		log.Fatalf("Failed to bulk decrypt models: %v", err)
 	}
@@ -114,23 +123,17 @@ func main() {
 	}
 
 	// ---------------------------------------------------------------
-	// 4. Single value encryption and decryption
+	// 5. Single value encryption and decryption
 	// ---------------------------------------------------------------
 
-	encrypted, err := client.Encrypt(protect.EncryptOptions{
-		Plaintext: "john.doe@example.com",
-		Table:     "users",
-		Column:    "email",
-	})
+	encrypted, err := client.Encrypt(ctx, users.Column("email"), "john.doe@example.com")
 	if err != nil {
 		log.Fatalf("Failed to encrypt: %v", err)
 	}
 
 	fmt.Printf("\nEncrypted single value (has unique index: %v)\n", encrypted.UniqueIndex != nil)
 
-	plaintext, err := client.Decrypt(protect.DecryptOptions{
-		Ciphertext: encrypted,
-	})
+	plaintext, err := client.Decrypt(ctx, encrypted)
 	if err != nil {
 		log.Fatalf("Failed to decrypt: %v", err)
 	}
@@ -138,16 +141,11 @@ func main() {
 	fmt.Printf("Decrypted: %v\n", plaintext)
 
 	// ---------------------------------------------------------------
-	// 5. Query encryption (for searching encrypted columns)
+	// 6. Query encryption (for searching encrypted columns)
 	// ---------------------------------------------------------------
 
 	// Exact match query
-	queryResult, err := client.EncryptQuery(protect.EncryptQueryOptions{
-		Plaintext: "john.doe@example.com",
-		Column:    "email",
-		Table:     "users",
-		IndexType: protect.IndexTypeUnique,
-	})
+	queryResult, err := client.EncryptQuery(ctx, users.Column("email"), protect.Equality, "john.doe@example.com")
 	if err != nil {
 		log.Fatalf("Failed to encrypt query: %v", err)
 	}
@@ -155,12 +153,7 @@ func main() {
 	fmt.Printf("\nEncrypted equality query (unique index: %s)\n", *queryResult.UniqueIndex)
 
 	// Full-text search query
-	searchResult, err := client.EncryptQuery(protect.EncryptQueryOptions{
-		Plaintext: "john",
-		Column:    "name",
-		Table:     "users",
-		IndexType: protect.IndexTypeMatch,
-	})
+	searchResult, err := client.EncryptQuery(ctx, users.Column("name"), protect.FreeTextSearch, "john")
 	if err != nil {
 		log.Fatalf("Failed to encrypt search query: %v", err)
 	}
@@ -168,12 +161,7 @@ func main() {
 	fmt.Printf("Encrypted match query (bloom filter length: %d)\n", len(*searchResult.MatchIndex))
 
 	// Range query
-	rangeResult, err := client.EncryptQuery(protect.EncryptQueryOptions{
-		Plaintext: 25,
-		Column:    "age",
-		Table:     "users",
-		IndexType: protect.IndexTypeOre,
-	})
+	rangeResult, err := client.EncryptQuery(ctx, users.Column("age"), protect.OrderAndRange, 25)
 	if err != nil {
 		log.Fatalf("Failed to encrypt range query: %v", err)
 	}
@@ -181,11 +169,9 @@ func main() {
 	fmt.Printf("Encrypted range query (ORE index length: %d)\n", len(*rangeResult.OreIndex))
 
 	// Bulk query encryption
-	bulkQueries, err := client.EncryptQueryBulk(protect.EncryptQueryBulkOptions{
-		Queries: []protect.QueryPayload{
-			{Plaintext: "alice@example.com", Column: "email", Table: "users", IndexType: protect.IndexTypeUnique},
-			{Plaintext: "bob", Column: "name", Table: "users", IndexType: protect.IndexTypeMatch},
-		},
+	bulkQueries, err := client.EncryptQueryBulk(ctx, []protect.QueryItem{
+		{Column: users.Column("email"), QueryType: protect.Equality, Plaintext: "alice@example.com"},
+		{Column: users.Column("name"), QueryType: protect.FreeTextSearch, Plaintext: "bob"},
 	})
 	if err != nil {
 		log.Fatalf("Failed to bulk encrypt queries: %v", err)
@@ -194,27 +180,23 @@ func main() {
 	fmt.Printf("Bulk encrypted %d queries\n", len(bulkQueries))
 
 	// ---------------------------------------------------------------
-	// 6. Bulk encrypt and decrypt individual values
+	// 7. Bulk encrypt and decrypt individual values
 	// ---------------------------------------------------------------
 
-	bulkEncrypted, err := client.EncryptBulk(protect.EncryptBulkOptions{
-		Plaintexts: []protect.PlaintextPayload{
-			{Plaintext: "alice@example.com", Table: "users", Column: "email"},
-			{Plaintext: "bob@example.com", Table: "users", Column: "email"},
-		},
+	bulkEncrypted, err := client.EncryptBulk(ctx, []protect.PlaintextItem{
+		{Column: users.Column("email"), Plaintext: "alice@example.com"},
+		{Column: users.Column("email"), Plaintext: "bob@example.com"},
 	})
 	if err != nil {
 		log.Fatalf("Failed to bulk encrypt: %v", err)
 	}
 
-	ciphertexts := make([]protect.BulkDecryptPayload, len(bulkEncrypted))
+	decryptItems := make([]*protect.Encrypted, len(bulkEncrypted))
 	for i := range bulkEncrypted {
-		ciphertexts[i] = protect.BulkDecryptPayload{Ciphertext: &bulkEncrypted[i]}
+		decryptItems[i] = &bulkEncrypted[i]
 	}
 
-	bulkPlaintexts, err := client.DecryptBulk(protect.DecryptBulkOptions{
-		Ciphertexts: ciphertexts,
-	})
+	bulkPlaintexts, err := client.DecryptBulk(ctx, decryptItems)
 	if err != nil {
 		log.Fatalf("Failed to bulk decrypt: %v", err)
 	}
@@ -222,53 +204,47 @@ func main() {
 	fmt.Printf("\nBulk decrypted: %v\n", bulkPlaintexts)
 
 	// ---------------------------------------------------------------
-	// 7. Fallible bulk decryption (per-item error handling)
+	// 8. Fallible bulk decryption (per-item error handling)
 	// ---------------------------------------------------------------
 
-	fallibleResults, err := client.DecryptBulkFallible(protect.DecryptBulkOptions{
-		Ciphertexts: ciphertexts,
-	})
+	fallibleResults, err := client.DecryptBulkFallible(ctx, decryptItems)
 	if err != nil {
 		log.Fatalf("Failed to bulk decrypt fallible: %v", err)
 	}
 
 	for i, result := range fallibleResults {
-		if result.Error != nil {
-			fmt.Printf("  Result %d: error - %s\n", i, *result.Error)
+		if result.Err != nil {
+			fmt.Printf("  Result %d: error - %s\n", i, result.Err)
 		} else {
 			fmt.Printf("  Result %d: %v\n", i, result.Data)
 		}
 	}
 
 	// ---------------------------------------------------------------
-	// 8. IsEncrypted validation
+	// 9. IsEncrypted validation
 	// ---------------------------------------------------------------
 
 	fmt.Printf("\nIsEncrypted(encrypted value): %v\n", protect.IsEncrypted(encrypted))
 	fmt.Printf("IsEncrypted(plain string):    %v\n", protect.IsEncrypted("not encrypted"))
 
 	// ---------------------------------------------------------------
-	// 9. Identity-aware encryption (lock context)
+	// 10. Identity-aware encryption (lock context)
 	// ---------------------------------------------------------------
 
 	lockContext := &protect.LockContext{
 		IdentityClaim: []string{"user:12345"},
 	}
 
-	lockedEncrypted, err := client.Encrypt(protect.EncryptOptions{
-		Plaintext:   "secret-data",
-		Table:       "users",
-		Column:      "email",
-		LockContext: lockContext,
-	})
+	lockedEncrypted, err := client.Encrypt(ctx, users.Column("email"), "secret-data",
+		protect.WithLockContext(lockContext),
+	)
 	if err != nil {
 		log.Fatalf("Failed to encrypt with lock context: %v", err)
 	}
 
-	lockedPlaintext, err := client.Decrypt(protect.DecryptOptions{
-		Ciphertext:  lockedEncrypted,
-		LockContext: lockContext,
-	})
+	lockedPlaintext, err := client.Decrypt(ctx, lockedEncrypted,
+		protect.WithLockContext(lockContext),
+	)
 	if err != nil {
 		log.Fatalf("Failed to decrypt with lock context: %v", err)
 	}
@@ -276,23 +252,15 @@ func main() {
 	fmt.Printf("Identity-aware decrypt: %v\n", lockedPlaintext)
 
 	// ---------------------------------------------------------------
-	// 10. Structured error handling
+	// 11. Error handling with errors.Is
 	// ---------------------------------------------------------------
 
-	_, err = client.Encrypt(protect.EncryptOptions{
-		Plaintext: "test",
-		Table:     "users",
-		Column:    "nonexistent",
-	})
+	_, err = client.Encrypt(ctx, users.Column("email"), "test")
 	if err != nil {
-		if encErr, ok := err.(*protect.EncryptionError); ok {
-			fmt.Printf("\nStructured error:\n")
-			fmt.Printf("  Code:    %s\n", encErr.Code)
-			fmt.Printf("  Message: %s\n", encErr.Message)
+		if errors.Is(err, protect.ErrUnknownColumn) {
+			fmt.Println("Column not found in schema")
+		} else {
+			fmt.Printf("Error: %v\n", err)
 		}
 	}
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }

--- a/examples/basic_usage.go
+++ b/examples/basic_usage.go
@@ -8,226 +8,289 @@ import (
 	"github.com/cipherstash/protectgo/pkg/protect"
 )
 
-func main() {
-	// Configure encryption settings
-	config := protect.EncryptConfig{
-		Version: 1,
-		Tables: protect.Tables{
-			"users": protect.Table{
-				"email": protect.Column{
-					CastAs: ptr(protect.CastAsText),
-					Indexes: &protect.Indexes{
-						OreIndex: &protect.OreIndexOpts{},
-						UniqueIndex: &protect.UniqueIndexOpts{
-							TokenFilters: []protect.TokenFilter{
-								{Kind: "downcase"},
-							},
-						},
-					},
-				},
-				"name": protect.Column{
-					CastAs: ptr(protect.CastAsText),
-					Indexes: &protect.Indexes{
-						MatchIndex: &protect.MatchIndexOpts{
-							K:               ptr(6),
-							M:               ptr(2048),
-							IncludeOriginal: ptr(false),
-						},
-					},
-				},
-				"age": protect.Column{
-					CastAs: ptr(protect.CastAsNumber),
-					Indexes: &protect.Indexes{
-						OreIndex: &protect.OreIndexOpts{},
-					},
-				},
-				"active": protect.Column{
-					CastAs: ptr(protect.CastAsBoolean),
-				},
-			},
-		},
-	}
+// Define your data model with encryption schema using struct tags.
+//
+// The `cs` tag defines:
+//   - Column name (first value)
+//   - Index types: unique, match, ore, ste_vec
+//   - Cast type override: cast=number, cast=boolean, etc.
+//
+// Fields without a `cs` tag are not encrypted.
+type User struct {
+	ID      int    `json:"id"`
+	Email   string `json:"email"   cs:"email,unique(downcase),match"`
+	Name    string `json:"name"    cs:"name,match"`
+	Age     int    `json:"age"     cs:"age,cast=number,ore"`
+	Active  bool   `json:"active"  cs:"active,cast=boolean"`
+	Profile any    `json:"profile" cs:"profile,ste_vec(prefix=users/profile)"`
+	Role    string `json:"role"` // not encrypted
+}
 
-	// Create client options with optional keyset configuration
-	clientOpts := protect.NewClientOptions{
+func main() {
+	// ---------------------------------------------------------------
+	// 1. Define schema from struct tags and create client
+	// ---------------------------------------------------------------
+
+	config := protect.BuildEncryptConfig(
+		protect.TableSchema("users", User{}),
+	)
+
+	client, err := protect.NewClient(protect.NewClientOptions{
 		EncryptConfig: config,
 		ClientOpts: &protect.ClientOpts{
-			WorkspaceCrn: ptr(os.Getenv("CIPHERSTASH_WORKSPACE_CRN")),
-			AccessKey:    ptr(os.Getenv("CIPHERSTASH_ACCESS_KEY")),
-			ClientID:     ptr(os.Getenv("CIPHERSTASH_CLIENT_ID")),
-			ClientKey:    ptr(os.Getenv("CIPHERSTASH_CLIENT_KEY")),
-			Keyset: &protect.KeysetConfig{
-				Name: ptr("my-keyset"),
-			},
+			WorkspaceCrn: ptr(os.Getenv("CS_WORKSPACE_CRN")),
+			AccessKey:    ptr(os.Getenv("CS_CLIENT_ACCESS_KEY")),
+			ClientID:     ptr(os.Getenv("CS_CLIENT_ID")),
+			ClientKey:    ptr(os.Getenv("CS_CLIENT_KEY")),
 		},
-	}
-
-	// Create a new client
-	client, err := protect.NewClient(clientOpts)
+	})
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 	defer client.Free()
 
-	// Example 1: Encrypt a string value
-	encryptOpts := protect.EncryptOptions{
+	// ---------------------------------------------------------------
+	// 2. Encrypt and decrypt a model (struct-based)
+	// ---------------------------------------------------------------
+
+	user := User{
+		ID:    1,
+		Email: "john.doe@example.com",
+		Name:  "John Doe",
+		Age:   30,
+		Active: true,
+		Role:  "admin",
+	}
+
+	encryptedMap, err := client.EncryptModel(user, "users")
+	if err != nil {
+		log.Fatalf("Failed to encrypt model: %v", err)
+	}
+
+	fmt.Println("Encrypted model:")
+	fmt.Printf("  id (plain):    %v\n", encryptedMap["id"])
+	fmt.Printf("  role (plain):  %v\n", encryptedMap["role"])
+	fmt.Printf("  email:         [encrypted]\n")
+	fmt.Printf("  name:          [encrypted]\n")
+	fmt.Printf("  age:           [encrypted]\n")
+	fmt.Printf("  active:        [encrypted]\n")
+
+	var decryptedUser User
+	err = client.DecryptModel(encryptedMap, "users", &decryptedUser)
+	if err != nil {
+		log.Fatalf("Failed to decrypt model: %v", err)
+	}
+
+	fmt.Printf("\nDecrypted model:\n")
+	fmt.Printf("  Email: %s\n", decryptedUser.Email)
+	fmt.Printf("  Name:  %s\n", decryptedUser.Name)
+	fmt.Printf("  Age:   %d\n", decryptedUser.Age)
+	fmt.Printf("  Role:  %s\n", decryptedUser.Role)
+
+	// ---------------------------------------------------------------
+	// 3. Bulk encrypt and decrypt models (single KMS call)
+	// ---------------------------------------------------------------
+
+	users := []User{
+		{ID: 1, Email: "alice@example.com", Name: "Alice", Age: 28, Active: true, Role: "admin"},
+		{ID: 2, Email: "bob@example.com", Name: "Bob", Age: 35, Active: false, Role: "user"},
+	}
+
+	encryptedModels, err := client.BulkEncryptModels(users, "users")
+	if err != nil {
+		log.Fatalf("Failed to bulk encrypt models: %v", err)
+	}
+
+	fmt.Printf("\nBulk encrypted %d models\n", len(encryptedModels))
+
+	var decryptedUsers []User
+	err = client.BulkDecryptModels(encryptedModels, "users", &decryptedUsers)
+	if err != nil {
+		log.Fatalf("Failed to bulk decrypt models: %v", err)
+	}
+
+	for _, u := range decryptedUsers {
+		fmt.Printf("  %s <%s> (age %d)\n", u.Name, u.Email, u.Age)
+	}
+
+	// ---------------------------------------------------------------
+	// 4. Single value encryption and decryption
+	// ---------------------------------------------------------------
+
+	encrypted, err := client.Encrypt(protect.EncryptOptions{
 		Plaintext: "john.doe@example.com",
 		Table:     "users",
 		Column:    "email",
-	}
-
-	encrypted, err := client.Encrypt(encryptOpts)
+	})
 	if err != nil {
 		log.Fatalf("Failed to encrypt: %v", err)
 	}
 
-	fmt.Printf("Encrypted email: %s\n", *encrypted.Ciphertext)
-	if encrypted.OreIndex != nil {
-		fmt.Printf("ORE index: %v\n", *encrypted.OreIndex)
-	}
-	if encrypted.UniqueIndex != nil {
-		fmt.Printf("Unique index: %s\n", *encrypted.UniqueIndex)
-	}
+	fmt.Printf("\nEncrypted single value (has unique index: %v)\n", encrypted.UniqueIndex != nil)
 
-	// Example 2: Encrypt a numeric value
-	ageEncrypted, err := client.Encrypt(protect.EncryptOptions{
-		Plaintext: 30,
-		Table:     "users",
-		Column:    "age",
-	})
-	if err != nil {
-		log.Fatalf("Failed to encrypt age: %v", err)
-	}
-
-	fmt.Printf("Encrypted age ciphertext: %s\n", *ageEncrypted.Ciphertext)
-
-	// Example 3: Encrypt a boolean value
-	activeEncrypted, err := client.Encrypt(protect.EncryptOptions{
-		Plaintext: true,
-		Table:     "users",
-		Column:    "active",
-	})
-	if err != nil {
-		log.Fatalf("Failed to encrypt active: %v", err)
-	}
-
-	fmt.Printf("Encrypted active ciphertext: %s\n", *activeEncrypted.Ciphertext)
-
-	// Example 4: Decrypt the value (returns interface{})
-	decryptOpts := protect.DecryptOptions{
+	plaintext, err := client.Decrypt(protect.DecryptOptions{
 		Ciphertext: encrypted,
-	}
-
-	plaintext, err := client.Decrypt(decryptOpts)
+	})
 	if err != nil {
 		log.Fatalf("Failed to decrypt: %v", err)
 	}
 
-	fmt.Printf("Decrypted email: %v\n", plaintext)
+	fmt.Printf("Decrypted: %v\n", plaintext)
 
-	// Example 5: Check if a value is encrypted
-	if protect.IsEncrypted(encrypted) {
-		fmt.Println("Value is encrypted")
-	}
+	// ---------------------------------------------------------------
+	// 5. Query encryption (for searching encrypted columns)
+	// ---------------------------------------------------------------
 
-	if !protect.IsEncrypted("not encrypted") {
-		fmt.Println("Plain string is not encrypted")
-	}
-
-	// Example 6: Encrypt a query for searching
-	queryEncrypted, err := client.EncryptQuery(protect.EncryptQueryOptions{
-		Plaintext: "john",
-		Column:    "name",
+	// Exact match query
+	queryResult, err := client.EncryptQuery(protect.EncryptQueryOptions{
+		Plaintext: "john.doe@example.com",
+		Column:    "email",
 		Table:     "users",
-		IndexType: protect.IndexTypeMatch,
-		QueryOp:   protect.QueryOpDefault,
+		IndexType: protect.IndexTypeUnique,
 	})
 	if err != nil {
 		log.Fatalf("Failed to encrypt query: %v", err)
 	}
 
-	fmt.Printf("Encrypted query match index: %v\n", queryEncrypted.MatchIndex)
+	fmt.Printf("\nEncrypted equality query (unique index: %s)\n", *queryResult.UniqueIndex)
 
-	// Example 7: Bulk encryption with mixed types
-	bulkEncryptOpts := protect.EncryptBulkOptions{
-		Plaintexts: []protect.PlaintextPayload{
-			{
-				Plaintext: "Alice Smith",
-				Table:     "users",
-				Column:    "name",
-			},
-			{
-				Plaintext: "Bob Johnson",
-				Table:     "users",
-				Column:    "name",
-			},
-		},
+	// Full-text search query
+	searchResult, err := client.EncryptQuery(protect.EncryptQueryOptions{
+		Plaintext: "john",
+		Column:    "name",
+		Table:     "users",
+		IndexType: protect.IndexTypeMatch,
+	})
+	if err != nil {
+		log.Fatalf("Failed to encrypt search query: %v", err)
 	}
 
-	bulkEncrypted, err := client.EncryptBulk(bulkEncryptOpts)
+	fmt.Printf("Encrypted match query (bloom filter length: %d)\n", len(*searchResult.MatchIndex))
+
+	// Range query
+	rangeResult, err := client.EncryptQuery(protect.EncryptQueryOptions{
+		Plaintext: 25,
+		Column:    "age",
+		Table:     "users",
+		IndexType: protect.IndexTypeOre,
+	})
+	if err != nil {
+		log.Fatalf("Failed to encrypt range query: %v", err)
+	}
+
+	fmt.Printf("Encrypted range query (ORE index length: %d)\n", len(*rangeResult.OreIndex))
+
+	// Bulk query encryption
+	bulkQueries, err := client.EncryptQueryBulk(protect.EncryptQueryBulkOptions{
+		Queries: []protect.QueryPayload{
+			{Plaintext: "alice@example.com", Column: "email", Table: "users", IndexType: protect.IndexTypeUnique},
+			{Plaintext: "bob", Column: "name", Table: "users", IndexType: protect.IndexTypeMatch},
+		},
+	})
+	if err != nil {
+		log.Fatalf("Failed to bulk encrypt queries: %v", err)
+	}
+
+	fmt.Printf("Bulk encrypted %d queries\n", len(bulkQueries))
+
+	// ---------------------------------------------------------------
+	// 6. Bulk encrypt and decrypt individual values
+	// ---------------------------------------------------------------
+
+	bulkEncrypted, err := client.EncryptBulk(protect.EncryptBulkOptions{
+		Plaintexts: []protect.PlaintextPayload{
+			{Plaintext: "alice@example.com", Table: "users", Column: "email"},
+			{Plaintext: "bob@example.com", Table: "users", Column: "email"},
+		},
+	})
 	if err != nil {
 		log.Fatalf("Failed to bulk encrypt: %v", err)
 	}
 
-	fmt.Printf("Bulk encrypted %d items\n", len(bulkEncrypted))
-
-	// Example 8: Bulk decryption (pass *Encrypted values)
 	ciphertexts := make([]protect.BulkDecryptPayload, len(bulkEncrypted))
 	for i := range bulkEncrypted {
-		ciphertexts[i] = protect.BulkDecryptPayload{
-			Ciphertext: &bulkEncrypted[i],
-		}
+		ciphertexts[i] = protect.BulkDecryptPayload{Ciphertext: &bulkEncrypted[i]}
 	}
 
-	bulkDecryptOpts := protect.DecryptBulkOptions{
+	bulkPlaintexts, err := client.DecryptBulk(protect.DecryptBulkOptions{
 		Ciphertexts: ciphertexts,
-	}
-
-	bulkPlaintexts, err := client.DecryptBulk(bulkDecryptOpts)
+	})
 	if err != nil {
 		log.Fatalf("Failed to bulk decrypt: %v", err)
 	}
 
-	fmt.Printf("Bulk decrypted values: %v\n", bulkPlaintexts)
+	fmt.Printf("\nBulk decrypted: %v\n", bulkPlaintexts)
 
-	// Example 9: Bulk decryption with fallible results
-	fallibleResults, err := client.DecryptBulkFallible(bulkDecryptOpts)
+	// ---------------------------------------------------------------
+	// 7. Fallible bulk decryption (per-item error handling)
+	// ---------------------------------------------------------------
+
+	fallibleResults, err := client.DecryptBulkFallible(protect.DecryptBulkOptions{
+		Ciphertexts: ciphertexts,
+	})
 	if err != nil {
 		log.Fatalf("Failed to bulk decrypt fallible: %v", err)
 	}
 
 	for i, result := range fallibleResults {
-		if result.Data != nil {
-			fmt.Printf("Result %d: %v\n", i, result.Data)
+		if result.Error != nil {
+			fmt.Printf("  Result %d: error - %s\n", i, *result.Error)
 		} else {
-			fmt.Printf("Result %d: Error - %s\n", i, *result.Error)
+			fmt.Printf("  Result %d: %v\n", i, result.Data)
 		}
 	}
 
-	// Example 10: Bulk query encryption
-	bulkQueryOpts := protect.EncryptQueryBulkOptions{
-		Queries: []protect.QueryPayload{
-			{
-				Plaintext: "alice",
-				Column:    "name",
-				Table:     "users",
-				IndexType: protect.IndexTypeMatch,
-			},
-			{
-				Plaintext: "bob",
-				Column:    "name",
-				Table:     "users",
-				IndexType: protect.IndexTypeMatch,
-			},
-		},
+	// ---------------------------------------------------------------
+	// 8. IsEncrypted validation
+	// ---------------------------------------------------------------
+
+	fmt.Printf("\nIsEncrypted(encrypted value): %v\n", protect.IsEncrypted(encrypted))
+	fmt.Printf("IsEncrypted(plain string):    %v\n", protect.IsEncrypted("not encrypted"))
+
+	// ---------------------------------------------------------------
+	// 9. Identity-aware encryption (lock context)
+	// ---------------------------------------------------------------
+
+	lockContext := &protect.LockContext{
+		IdentityClaim: []string{"user:12345"},
 	}
 
-	bulkQueryEncrypted, err := client.EncryptQueryBulk(bulkQueryOpts)
+	lockedEncrypted, err := client.Encrypt(protect.EncryptOptions{
+		Plaintext:   "secret-data",
+		Table:       "users",
+		Column:      "email",
+		LockContext: lockContext,
+	})
 	if err != nil {
-		log.Fatalf("Failed to bulk encrypt queries: %v", err)
+		log.Fatalf("Failed to encrypt with lock context: %v", err)
 	}
 
-	fmt.Printf("Bulk encrypted %d queries\n", len(bulkQueryEncrypted))
+	lockedPlaintext, err := client.Decrypt(protect.DecryptOptions{
+		Ciphertext:  lockedEncrypted,
+		LockContext: lockContext,
+	})
+	if err != nil {
+		log.Fatalf("Failed to decrypt with lock context: %v", err)
+	}
+
+	fmt.Printf("Identity-aware decrypt: %v\n", lockedPlaintext)
+
+	// ---------------------------------------------------------------
+	// 10. Structured error handling
+	// ---------------------------------------------------------------
+
+	_, err = client.Encrypt(protect.EncryptOptions{
+		Plaintext: "test",
+		Table:     "users",
+		Column:    "nonexistent",
+	})
+	if err != nil {
+		if encErr, ok := err.(*protect.EncryptionError); ok {
+			fmt.Printf("\nStructured error:\n")
+			fmt.Printf("  Code:    %s\n", encErr.Code)
+			fmt.Printf("  Message: %s\n", encErr.Message)
+		}
+	}
 }
 
 func ptr[T any](v T) *T {

--- a/examples/basic_usage.go
+++ b/examples/basic_usage.go
@@ -255,11 +255,27 @@ func main() {
 	// 11. Error handling with errors.Is
 	// ---------------------------------------------------------------
 
-	_, err = client.Encrypt(ctx, users.Column("email"), "test")
+	// Use ColumnOK for safe column lookup without panics.
+	if col, ok := users.ColumnOK("nonexistent_column"); ok {
+		_, err = client.Encrypt(ctx, col, "test")
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+	} else {
+		fmt.Println("Column not found in schema (caught safely with ColumnOK)")
+	}
+
+	// Programmatic error handling with sentinel errors.
+	_, err = client.EncryptQuery(ctx, users.Column("email"), protect.OrderAndRange, "test")
 	if err != nil {
-		if errors.Is(err, protect.ErrUnknownColumn) {
+		switch {
+		case errors.Is(err, protect.ErrMissingIndex):
+			fmt.Println("Index not configured for this query type (expected)")
+		case errors.Is(err, protect.ErrUnknownColumn):
 			fmt.Println("Column not found in schema")
-		} else {
+		case errors.Is(err, protect.ErrClientClosed):
+			fmt.Println("Client was already closed")
+		default:
 			fmt.Printf("Error: %v\n", err)
 		}
 	}

--- a/examples/basic_usage.go
+++ b/examples/basic_usage.go
@@ -35,11 +35,20 @@ func main() {
 						},
 					},
 				},
+				"age": protect.Column{
+					CastAs: ptr(protect.CastAsNumber),
+					Indexes: &protect.Indexes{
+						OreIndex: &protect.OreIndexOpts{},
+					},
+				},
+				"active": protect.Column{
+					CastAs: ptr(protect.CastAsBoolean),
+				},
 			},
 		},
 	}
 
-	// Create client options
+	// Create client options with optional keyset configuration
 	clientOpts := protect.NewClientOptions{
 		EncryptConfig: config,
 		ClientOpts: &protect.ClientOpts{
@@ -47,6 +56,9 @@ func main() {
 			AccessKey:    ptr(os.Getenv("CIPHERSTASH_ACCESS_KEY")),
 			ClientID:     ptr(os.Getenv("CIPHERSTASH_CLIENT_ID")),
 			ClientKey:    ptr(os.Getenv("CIPHERSTASH_CLIENT_KEY")),
+			Keyset: &protect.KeysetConfig{
+				Name: ptr("my-keyset"),
+			},
 		},
 	}
 
@@ -57,7 +69,7 @@ func main() {
 	}
 	defer client.Free()
 
-	// Example 1: Encrypt a single value
+	// Example 1: Encrypt a string value
 	encryptOpts := protect.EncryptOptions{
 		Plaintext: "john.doe@example.com",
 		Table:     "users",
@@ -77,9 +89,33 @@ func main() {
 		fmt.Printf("Unique index: %s\n", *encrypted.UniqueIndex)
 	}
 
-	// Example 2: Decrypt the value
+	// Example 2: Encrypt a numeric value
+	ageEncrypted, err := client.Encrypt(protect.EncryptOptions{
+		Plaintext: 30,
+		Table:     "users",
+		Column:    "age",
+	})
+	if err != nil {
+		log.Fatalf("Failed to encrypt age: %v", err)
+	}
+
+	fmt.Printf("Encrypted age ciphertext: %s\n", *ageEncrypted.Ciphertext)
+
+	// Example 3: Encrypt a boolean value
+	activeEncrypted, err := client.Encrypt(protect.EncryptOptions{
+		Plaintext: true,
+		Table:     "users",
+		Column:    "active",
+	})
+	if err != nil {
+		log.Fatalf("Failed to encrypt active: %v", err)
+	}
+
+	fmt.Printf("Encrypted active ciphertext: %s\n", *activeEncrypted.Ciphertext)
+
+	// Example 4: Decrypt the value (returns interface{})
 	decryptOpts := protect.DecryptOptions{
-		Ciphertext: *encrypted.Ciphertext,
+		Ciphertext: encrypted,
 	}
 
 	plaintext, err := client.Decrypt(decryptOpts)
@@ -87,9 +123,32 @@ func main() {
 		log.Fatalf("Failed to decrypt: %v", err)
 	}
 
-	fmt.Printf("Decrypted email: %s\n", plaintext)
+	fmt.Printf("Decrypted email: %v\n", plaintext)
 
-	// Example 3: Bulk encryption
+	// Example 5: Check if a value is encrypted
+	if protect.IsEncrypted(encrypted) {
+		fmt.Println("Value is encrypted")
+	}
+
+	if !protect.IsEncrypted("not encrypted") {
+		fmt.Println("Plain string is not encrypted")
+	}
+
+	// Example 6: Encrypt a query for searching
+	queryEncrypted, err := client.EncryptQuery(protect.EncryptQueryOptions{
+		Plaintext: "john",
+		Column:    "name",
+		Table:     "users",
+		IndexType: protect.IndexTypeMatch,
+		QueryOp:   protect.QueryOpDefault,
+	})
+	if err != nil {
+		log.Fatalf("Failed to encrypt query: %v", err)
+	}
+
+	fmt.Printf("Encrypted query match index: %v\n", queryEncrypted.MatchIndex)
+
+	// Example 7: Bulk encryption with mixed types
 	bulkEncryptOpts := protect.EncryptBulkOptions{
 		Plaintexts: []protect.PlaintextPayload{
 			{
@@ -112,11 +171,11 @@ func main() {
 
 	fmt.Printf("Bulk encrypted %d items\n", len(bulkEncrypted))
 
-	// Example 4: Bulk decryption
+	// Example 8: Bulk decryption (pass *Encrypted values)
 	ciphertexts := make([]protect.BulkDecryptPayload, len(bulkEncrypted))
-	for i, enc := range bulkEncrypted {
+	for i := range bulkEncrypted {
 		ciphertexts[i] = protect.BulkDecryptPayload{
-			Ciphertext: *enc.Ciphertext,
+			Ciphertext: &bulkEncrypted[i],
 		}
 	}
 
@@ -131,7 +190,7 @@ func main() {
 
 	fmt.Printf("Bulk decrypted values: %v\n", bulkPlaintexts)
 
-	// Example 5: Bulk decryption with fallible results
+	// Example 9: Bulk decryption with fallible results
 	fallibleResults, err := client.DecryptBulkFallible(bulkDecryptOpts)
 	if err != nil {
 		log.Fatalf("Failed to bulk decrypt fallible: %v", err)
@@ -139,11 +198,36 @@ func main() {
 
 	for i, result := range fallibleResults {
 		if result.Data != nil {
-			fmt.Printf("Result %d: %s\n", i, *result.Data)
+			fmt.Printf("Result %d: %v\n", i, result.Data)
 		} else {
 			fmt.Printf("Result %d: Error - %s\n", i, *result.Error)
 		}
 	}
+
+	// Example 10: Bulk query encryption
+	bulkQueryOpts := protect.EncryptQueryBulkOptions{
+		Queries: []protect.QueryPayload{
+			{
+				Plaintext: "alice",
+				Column:    "name",
+				Table:     "users",
+				IndexType: protect.IndexTypeMatch,
+			},
+			{
+				Plaintext: "bob",
+				Column:    "name",
+				Table:     "users",
+				IndexType: protect.IndexTypeMatch,
+			},
+		},
+	}
+
+	bulkQueryEncrypted, err := client.EncryptQueryBulk(bulkQueryOpts)
+	if err != nil {
+		log.Fatalf("Failed to bulk encrypt queries: %v", err)
+	}
+
+	fmt.Printf("Bulk encrypted %d queries\n", len(bulkQueryEncrypted))
 }
 
 func ptr[T any](v T) *T {

--- a/pkg/protect/errors.go
+++ b/pkg/protect/errors.go
@@ -31,6 +31,11 @@ var (
 
 	// ErrSteVecRequiresJSON indicates an ste_vec index requires a JSON cast type.
 	ErrSteVecRequiresJSON = errors.New("protect: ste_vec requires json cast type")
+
+	// ErrFFI indicates an unclassified error from the FFI layer.
+	// Use errors.Is(err, ErrFFI) to check if an error originated from the
+	// underlying encryption engine when no more specific sentinel applies.
+	ErrFFI = errors.New("protect: FFI error")
 )
 
 // Error is a structured error from the encryption SDK.
@@ -79,6 +84,6 @@ func inferSentinel(msg string) error {
 	case strings.Contains(msg, "ste_vec index requires cast_as"):
 		return ErrSteVecRequiresJSON
 	default:
-		return nil
+		return ErrFFI
 	}
 }

--- a/pkg/protect/errors.go
+++ b/pkg/protect/errors.go
@@ -1,0 +1,84 @@
+package protect
+
+import (
+	"errors"
+	"strings"
+)
+
+// Sentinel errors returned by the protect SDK. Use errors.Is() to check
+// for specific error conditions.
+var (
+	// ErrUnknownColumn indicates the column was not found in the encrypt config.
+	ErrUnknownColumn = errors.New("protect: unknown column")
+
+	// ErrMissingIndex indicates the column does not have the required index type.
+	ErrMissingIndex = errors.New("protect: missing index")
+
+	// ErrInvalidQueryInput indicates the query input value is invalid for the index type.
+	ErrInvalidQueryInput = errors.New("protect: invalid query input")
+
+	// ErrInvalidJSONPath indicates an invalid JSON path was provided.
+	ErrInvalidJSONPath = errors.New("protect: invalid JSON path")
+
+	// ErrUnknownQueryOp indicates an unknown query operation was requested.
+	ErrUnknownQueryOp = errors.New("protect: unknown query operation")
+
+	// ErrClientClosed indicates the client has already been closed.
+	ErrClientClosed = errors.New("protect: client is closed")
+
+	// ErrInvariantViolation indicates an internal invariant was violated.
+	ErrInvariantViolation = errors.New("protect: invariant violation")
+
+	// ErrSteVecRequiresJSON indicates an ste_vec index requires a JSON cast type.
+	ErrSteVecRequiresJSON = errors.New("protect: ste_vec requires json cast type")
+)
+
+// Error is a structured error from the encryption SDK.
+// Use errors.Is() to check for specific sentinel errors.
+type Error struct {
+	// Op is the operation that failed (e.g., "Encrypt", "Decrypt").
+	Op string
+
+	// Err is the wrapped sentinel error for use with errors.Is().
+	Err error
+
+	// Message is the original error message from the FFI layer.
+	Message string
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string { return e.Message }
+
+// Unwrap returns the underlying sentinel error for use with errors.Is().
+func (e *Error) Unwrap() error { return e.Err }
+
+// newError creates a new Error with the sentinel inferred from the FFI message.
+func newError(op, msg string) *Error {
+	return &Error{
+		Op:      op,
+		Err:     inferSentinel(msg),
+		Message: msg,
+	}
+}
+
+// inferSentinel maps FFI error message patterns to sentinel errors.
+func inferSentinel(msg string) error {
+	switch {
+	case strings.Contains(msg, "invariant violation"):
+		return ErrInvariantViolation
+	case strings.Contains(msg, "Unknown query operation"):
+		return ErrUnknownQueryOp
+	case strings.Contains(msg, "not found in Encrypt config"):
+		return ErrUnknownColumn
+	case strings.Contains(msg, "does not have a"):
+		return ErrMissingIndex
+	case strings.Contains(msg, "Invalid query input"):
+		return ErrInvalidQueryInput
+	case strings.Contains(msg, "Invalid JSON path"):
+		return ErrInvalidJSONPath
+	case strings.Contains(msg, "ste_vec index requires cast_as"):
+		return ErrSteVecRequiresJSON
+	default:
+		return nil
+	}
+}

--- a/pkg/protect/model.go
+++ b/pkg/protect/model.go
@@ -124,20 +124,26 @@ func fieldPlaintext(v reflect.Value) (any, bool) {
 // `cs:"column_name"` tag is encrypted using [Client.Encrypt]. Fields without
 // the tag are copied as-is.
 func (c *Client) EncryptModel(ctx context.Context, schema *TableDef, model any) (map[string]any, error) {
+	if _, unlock, err := c.acquirePtr("EncryptModel"); err != nil {
+		return nil, err
+	} else {
+		unlock()
+	}
+
 	v := reflect.ValueOf(model)
 	if v.Kind() == reflect.Ptr {
 		if v.IsNil() {
-			return nil, fmt.Errorf("model must not be nil")
+			return nil, fmt.Errorf("protect: EncryptModel: model must not be nil")
 		}
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("model must be a struct, got %s", v.Kind())
+		return nil, fmt.Errorf("protect: EncryptModel: model must be a struct, got %s", v.Kind())
 	}
 
 	info, err := analyzeStruct(v.Type())
 	if err != nil {
-		return nil, fmt.Errorf("analyzing model: %w", err)
+		return nil, fmt.Errorf("protect: EncryptModel: analyzing model: %w", err)
 	}
 
 	result := make(map[string]any, len(info.EncryptedFields)+len(info.PlainFields))
@@ -157,7 +163,7 @@ func (c *Client) EncryptModel(ctx context.Context, schema *TableDef, model any) 
 
 		encrypted, err := c.Encrypt(ctx, schema.Column(ef.Column), plaintext)
 		if err != nil {
-			return nil, fmt.Errorf("encrypting field %q (column %q): %w", ef.MapKey, ef.Column, err)
+			return nil, fmt.Errorf("protect: EncryptModel: field %q (column %q): %w", ef.MapKey, ef.Column, err)
 		}
 		result[ef.MapKey] = encrypted
 	}
@@ -172,18 +178,24 @@ func (c *Client) EncryptModel(ctx context.Context, schema *TableDef, model any) 
 // payload, decrypted using [Client.Decrypt], and the resulting plaintext is set on the
 // field. Non-tagged fields are set directly from the map.
 func (c *Client) DecryptModel(ctx context.Context, schema *TableDef, data map[string]any, dest any) error {
+	if _, unlock, err := c.acquirePtr("DecryptModel"); err != nil {
+		return err
+	} else {
+		unlock()
+	}
+
 	v := reflect.ValueOf(dest)
 	if v.Kind() != reflect.Ptr || v.IsNil() {
-		return fmt.Errorf("dest must be a non-nil pointer to a struct")
+		return fmt.Errorf("protect: DecryptModel: dest must be a non-nil pointer to a struct")
 	}
 	v = v.Elem()
 	if v.Kind() != reflect.Struct {
-		return fmt.Errorf("dest must be a pointer to a struct, got pointer to %s", v.Kind())
+		return fmt.Errorf("protect: DecryptModel: dest must be a pointer to a struct, got pointer to %s", v.Kind())
 	}
 
 	info, err := analyzeStruct(v.Type())
 	if err != nil {
-		return fmt.Errorf("analyzing dest: %w", err)
+		return fmt.Errorf("protect: DecryptModel: analyzing dest: %w", err)
 	}
 
 	// Set plain fields.
@@ -204,12 +216,12 @@ func (c *Client) DecryptModel(ctx context.Context, schema *TableDef, data map[st
 
 		encrypted, err := toEncrypted(rawVal)
 		if err != nil {
-			return fmt.Errorf("converting field %q to Encrypted: %w", ef.MapKey, err)
+			return fmt.Errorf("protect: DecryptModel: converting field %q to Encrypted: %w", ef.MapKey, err)
 		}
 
 		plaintext, err := c.Decrypt(ctx, encrypted)
 		if err != nil {
-			return fmt.Errorf("decrypting field %q (column %q): %w", ef.MapKey, ef.Column, err)
+			return fmt.Errorf("protect: DecryptModel: field %q (column %q): %w", ef.MapKey, ef.Column, err)
 		}
 
 		setFieldValue(v.Field(ef.Index), plaintext)
@@ -224,15 +236,21 @@ func (c *Client) DecryptModel(ctx context.Context, schema *TableDef, data map[st
 // `cs`-tagged fields are collected into a single call to [Client.EncryptBulk], which is
 // significantly more efficient than calling [Client.EncryptModel] for each struct individually.
 func (c *Client) BulkEncryptModels(ctx context.Context, schema *TableDef, models any) ([]map[string]any, error) {
+	if _, unlock, err := c.acquirePtr("BulkEncryptModels"); err != nil {
+		return nil, err
+	} else {
+		unlock()
+	}
+
 	sv := reflect.ValueOf(models)
 	if sv.Kind() == reflect.Ptr {
 		if sv.IsNil() {
-			return nil, fmt.Errorf("models must not be nil")
+			return nil, fmt.Errorf("protect: BulkEncryptModels: models must not be nil")
 		}
 		sv = sv.Elem()
 	}
 	if sv.Kind() != reflect.Slice {
-		return nil, fmt.Errorf("models must be a slice, got %s", sv.Kind())
+		return nil, fmt.Errorf("protect: BulkEncryptModels: models must be a slice, got %s", sv.Kind())
 	}
 	if sv.Len() == 0 {
 		return []map[string]any{}, nil
@@ -245,7 +263,7 @@ func (c *Client) BulkEncryptModels(ctx context.Context, schema *TableDef, models
 
 	info, err := analyzeStruct(elemType)
 	if err != nil {
-		return nil, fmt.Errorf("analyzing model type: %w", err)
+		return nil, fmt.Errorf("protect: BulkEncryptModels: analyzing model type: %w", err)
 	}
 
 	numModels := sv.Len()
@@ -301,11 +319,11 @@ func (c *Client) BulkEncryptModels(ctx context.Context, schema *TableDef, models
 
 	encrypted, err := c.EncryptBulk(ctx, payloads)
 	if err != nil {
-		return nil, fmt.Errorf("bulk encrypting models: %w", err)
+		return nil, fmt.Errorf("protect: BulkEncryptModels: %w", err)
 	}
 
 	if len(encrypted) != len(positions) {
-		return nil, fmt.Errorf("bulk encrypt returned %d results, expected %d", len(encrypted), len(positions))
+		return nil, fmt.Errorf("protect: BulkEncryptModels: bulk encrypt returned %d results, expected %d", len(encrypted), len(positions))
 	}
 
 	// Distribute encrypted values back.
@@ -323,13 +341,19 @@ func (c *Client) BulkEncryptModels(ctx context.Context, schema *TableDef, models
 // across the maps are collected into a single call to [Client.DecryptBulk], which is
 // significantly more efficient than calling [Client.DecryptModel] for each map individually.
 func (c *Client) BulkDecryptModels(ctx context.Context, schema *TableDef, data []map[string]any, dest any) error {
+	if _, unlock, err := c.acquirePtr("BulkDecryptModels"); err != nil {
+		return err
+	} else {
+		unlock()
+	}
+
 	dv := reflect.ValueOf(dest)
 	if dv.Kind() != reflect.Ptr || dv.IsNil() {
-		return fmt.Errorf("dest must be a non-nil pointer to a slice of structs")
+		return fmt.Errorf("protect: BulkDecryptModels: dest must be a non-nil pointer to a slice of structs")
 	}
 	sliceVal := dv.Elem()
 	if sliceVal.Kind() != reflect.Slice {
-		return fmt.Errorf("dest must be a pointer to a slice, got pointer to %s", sliceVal.Kind())
+		return fmt.Errorf("protect: BulkDecryptModels: dest must be a pointer to a slice, got pointer to %s", sliceVal.Kind())
 	}
 
 	elemType := sliceVal.Type().Elem()
@@ -339,7 +363,7 @@ func (c *Client) BulkDecryptModels(ctx context.Context, schema *TableDef, data [
 
 	info, err := analyzeStruct(elemType)
 	if err != nil {
-		return fmt.Errorf("analyzing dest element type: %w", err)
+		return fmt.Errorf("protect: BulkDecryptModels: analyzing dest element type: %w", err)
 	}
 
 	numMaps := len(data)
@@ -360,7 +384,7 @@ func (c *Client) BulkDecryptModels(ctx context.Context, schema *TableDef, data [
 			}
 			encrypted, err := toEncrypted(rawVal)
 			if err != nil {
-				return fmt.Errorf("converting field %q in map[%d] to Encrypted: %w", ef.MapKey, i, err)
+				return fmt.Errorf("protect: BulkDecryptModels: converting field %q in map[%d] to Encrypted: %w", ef.MapKey, i, err)
 			}
 			ciphertexts = append(ciphertexts, encrypted)
 			positions = append(positions, decryptPos{mapIdx: i, fieldIdx: j})
@@ -390,11 +414,11 @@ func (c *Client) BulkDecryptModels(ctx context.Context, schema *TableDef, data [
 	if len(ciphertexts) > 0 {
 		plaintexts, err := c.DecryptBulk(ctx, ciphertexts)
 		if err != nil {
-			return fmt.Errorf("bulk decrypting models: %w", err)
+			return fmt.Errorf("protect: BulkDecryptModels: %w", err)
 		}
 
 		if len(plaintexts) != len(positions) {
-			return fmt.Errorf("bulk decrypt returned %d results, expected %d", len(plaintexts), len(positions))
+			return fmt.Errorf("protect: BulkDecryptModels: bulk decrypt returned %d results, expected %d", len(plaintexts), len(positions))
 		}
 
 		for i, pos := range positions {

--- a/pkg/protect/model.go
+++ b/pkg/protect/model.go
@@ -51,11 +51,19 @@ func analyzeStruct(typ reflect.Type) (*modelInfo, error) {
 		csTag, hasCS := field.Tag.Lookup("cs")
 
 		if hasCS && csTag != "-" && csTag != "" {
-			info.EncryptedFields = append(info.EncryptedFields, modelField{
-				Index:  i,
-				Column: csTag,
-				MapKey: mapKey,
-			})
+			columnName := strings.Split(csTag, ",")[0]
+			if columnName != "" && columnName != "-" {
+				info.EncryptedFields = append(info.EncryptedFields, modelField{
+					Index:  i,
+					Column: columnName,
+					MapKey: mapKey,
+				})
+			} else {
+				info.PlainFields = append(info.PlainFields, modelField{
+					Index:  i,
+					MapKey: mapKey,
+				})
+			}
 		} else {
 			info.PlainFields = append(info.PlainFields, modelField{
 				Index:  i,

--- a/pkg/protect/model.go
+++ b/pkg/protect/model.go
@@ -1,6 +1,7 @@
 package protect
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -105,7 +106,7 @@ func toSnakeCase(s string) string {
 
 // fieldPlaintext extracts the plaintext value from a struct field, handling pointer
 // types by dereferencing them. It returns the value and whether the field is nil.
-func fieldPlaintext(v reflect.Value) (interface{}, bool) {
+func fieldPlaintext(v reflect.Value) (any, bool) {
 	if v.Kind() == reflect.Ptr {
 		if v.IsNil() {
 			return nil, true
@@ -118,10 +119,11 @@ func fieldPlaintext(v reflect.Value) (interface{}, bool) {
 // EncryptModel encrypts the tagged fields of a struct and returns a map with
 // encrypted values for `cs`-tagged fields and original values for all other fields.
 //
-// The model parameter must be a struct (or pointer to struct). The table parameter
-// identifies the table in the encryption config. Each field with a `cs:"column_name"`
-// tag is encrypted using [Client.Encrypt]. Fields without the tag are copied as-is.
-func (c *Client) EncryptModel(model interface{}, table string) (map[string]interface{}, error) {
+// The model parameter must be a struct (or pointer to struct). The schema parameter
+// identifies the table and columns in the encryption config. Each field with a
+// `cs:"column_name"` tag is encrypted using [Client.Encrypt]. Fields without
+// the tag are copied as-is.
+func (c *Client) EncryptModel(ctx context.Context, schema *TableDef, model any) (map[string]any, error) {
 	v := reflect.ValueOf(model)
 	if v.Kind() == reflect.Ptr {
 		if v.IsNil() {
@@ -138,7 +140,7 @@ func (c *Client) EncryptModel(model interface{}, table string) (map[string]inter
 		return nil, fmt.Errorf("analyzing model: %w", err)
 	}
 
-	result := make(map[string]interface{}, len(info.EncryptedFields)+len(info.PlainFields))
+	result := make(map[string]any, len(info.EncryptedFields)+len(info.PlainFields))
 
 	// Copy plain fields.
 	for _, pf := range info.PlainFields {
@@ -153,11 +155,7 @@ func (c *Client) EncryptModel(model interface{}, table string) (map[string]inter
 			continue
 		}
 
-		encrypted, err := c.Encrypt(EncryptOptions{
-			Plaintext: plaintext,
-			Column:    ef.Column,
-			Table:     table,
-		})
+		encrypted, err := c.Encrypt(ctx, schema.Column(ef.Column), plaintext)
 		if err != nil {
 			return nil, fmt.Errorf("encrypting field %q (column %q): %w", ef.MapKey, ef.Column, err)
 		}
@@ -173,7 +171,7 @@ func (c *Client) EncryptModel(model interface{}, table string) (map[string]inter
 // a `cs:"column_name"` tag, the corresponding map value is treated as an [Encrypted]
 // payload, decrypted using [Client.Decrypt], and the resulting plaintext is set on the
 // field. Non-tagged fields are set directly from the map.
-func (c *Client) DecryptModel(data map[string]interface{}, table string, dest interface{}) error {
+func (c *Client) DecryptModel(ctx context.Context, schema *TableDef, data map[string]any, dest any) error {
 	v := reflect.ValueOf(dest)
 	if v.Kind() != reflect.Ptr || v.IsNil() {
 		return fmt.Errorf("dest must be a non-nil pointer to a struct")
@@ -209,9 +207,7 @@ func (c *Client) DecryptModel(data map[string]interface{}, table string, dest in
 			return fmt.Errorf("converting field %q to Encrypted: %w", ef.MapKey, err)
 		}
 
-		plaintext, err := c.Decrypt(DecryptOptions{
-			Ciphertext: encrypted,
-		})
+		plaintext, err := c.Decrypt(ctx, encrypted)
 		if err != nil {
 			return fmt.Errorf("decrypting field %q (column %q): %w", ef.MapKey, ef.Column, err)
 		}
@@ -227,7 +223,7 @@ func (c *Client) DecryptModel(data map[string]interface{}, table string, dest in
 // The models parameter must be a slice of structs (or pointer to slice). Each struct's
 // `cs`-tagged fields are collected into a single call to [Client.EncryptBulk], which is
 // significantly more efficient than calling [Client.EncryptModel] for each struct individually.
-func (c *Client) BulkEncryptModels(models interface{}, table string) ([]map[string]interface{}, error) {
+func (c *Client) BulkEncryptModels(ctx context.Context, schema *TableDef, models any) ([]map[string]any, error) {
 	sv := reflect.ValueOf(models)
 	if sv.Kind() == reflect.Ptr {
 		if sv.IsNil() {
@@ -239,7 +235,7 @@ func (c *Client) BulkEncryptModels(models interface{}, table string) ([]map[stri
 		return nil, fmt.Errorf("models must be a slice, got %s", sv.Kind())
 	}
 	if sv.Len() == 0 {
-		return []map[string]interface{}{}, nil
+		return []map[string]any{}, nil
 	}
 
 	elemType := sv.Type().Elem()
@@ -256,9 +252,9 @@ func (c *Client) BulkEncryptModels(models interface{}, table string) ([]map[stri
 	numEncFields := len(info.EncryptedFields)
 
 	// Build bulk plaintext payloads and result maps in one pass.
-	results := make([]map[string]interface{}, numModels)
-	var payloads []PlaintextPayload
-	// Track which payloads map to which result slot; -1 for nil/skipped fields.
+	results := make([]map[string]any, numModels)
+	var payloads []PlaintextItem
+	// Track which payloads map to which result slot.
 	type payloadPos struct {
 		modelIdx int
 		mapKey   string
@@ -275,7 +271,7 @@ func (c *Client) BulkEncryptModels(models interface{}, table string) ([]map[stri
 			elem = elem.Elem()
 		}
 
-		result := make(map[string]interface{}, numEncFields+len(info.PlainFields))
+		result := make(map[string]any, numEncFields+len(info.PlainFields))
 
 		// Copy plain fields.
 		for _, pf := range info.PlainFields {
@@ -289,10 +285,9 @@ func (c *Client) BulkEncryptModels(models interface{}, table string) ([]map[stri
 				result[ef.MapKey] = nil
 				continue
 			}
-			payloads = append(payloads, PlaintextPayload{
+			payloads = append(payloads, PlaintextItem{
 				Plaintext: plaintext,
-				Column:    ef.Column,
-				Table:     table,
+				Column:    schema.Column(ef.Column),
 			})
 			positions = append(positions, payloadPos{modelIdx: i, mapKey: ef.MapKey})
 		}
@@ -304,9 +299,7 @@ func (c *Client) BulkEncryptModels(models interface{}, table string) ([]map[stri
 		return results, nil
 	}
 
-	encrypted, err := c.EncryptBulk(EncryptBulkOptions{
-		Plaintexts: payloads,
-	})
+	encrypted, err := c.EncryptBulk(ctx, payloads)
 	if err != nil {
 		return nil, fmt.Errorf("bulk encrypting models: %w", err)
 	}
@@ -329,7 +322,7 @@ func (c *Client) BulkEncryptModels(models interface{}, table string) ([]map[stri
 // The dest parameter must be a pointer to a slice of structs. All encrypted values
 // across the maps are collected into a single call to [Client.DecryptBulk], which is
 // significantly more efficient than calling [Client.DecryptModel] for each map individually.
-func (c *Client) BulkDecryptModels(data []map[string]interface{}, table string, dest interface{}) error {
+func (c *Client) BulkDecryptModels(ctx context.Context, schema *TableDef, data []map[string]any, dest any) error {
 	dv := reflect.ValueOf(dest)
 	if dv.Kind() != reflect.Ptr || dv.IsNil() {
 		return fmt.Errorf("dest must be a non-nil pointer to a slice of structs")
@@ -356,7 +349,7 @@ func (c *Client) BulkDecryptModels(data []map[string]interface{}, table string, 
 		mapIdx   int
 		fieldIdx int // index into info.EncryptedFields
 	}
-	var ciphertexts []BulkDecryptPayload
+	var ciphertexts []*Encrypted
 	var positions []decryptPos
 
 	for i, m := range data {
@@ -369,9 +362,7 @@ func (c *Client) BulkDecryptModels(data []map[string]interface{}, table string, 
 			if err != nil {
 				return fmt.Errorf("converting field %q in map[%d] to Encrypted: %w", ef.MapKey, i, err)
 			}
-			ciphertexts = append(ciphertexts, BulkDecryptPayload{
-				Ciphertext: encrypted,
-			})
+			ciphertexts = append(ciphertexts, encrypted)
 			positions = append(positions, decryptPos{mapIdx: i, fieldIdx: j})
 		}
 	}
@@ -397,9 +388,7 @@ func (c *Client) BulkDecryptModels(data []map[string]interface{}, table string, 
 
 	// Bulk decrypt if there are any ciphertexts.
 	if len(ciphertexts) > 0 {
-		plaintexts, err := c.DecryptBulk(DecryptBulkOptions{
-			Ciphertexts: ciphertexts,
-		})
+		plaintexts, err := c.DecryptBulk(ctx, ciphertexts)
 		if err != nil {
 			return fmt.Errorf("bulk decrypting models: %w", err)
 		}
@@ -424,7 +413,7 @@ func (c *Client) BulkDecryptModels(data []map[string]interface{}, table string, 
 
 // toEncrypted converts a raw value (typically a map from JSON deserialization) into
 // an *Encrypted struct by marshaling to JSON and unmarshaling back.
-func toEncrypted(val interface{}) (*Encrypted, error) {
+func toEncrypted(val any) (*Encrypted, error) {
 	switch v := val.(type) {
 	case *Encrypted:
 		return v, nil
@@ -445,7 +434,7 @@ func toEncrypted(val interface{}) (*Encrypted, error) {
 
 // setFieldValue sets a struct field from an arbitrary value, handling type coercion
 // for common cases (e.g., JSON numbers to int fields, strings to string fields).
-func setFieldValue(field reflect.Value, val interface{}) {
+func setFieldValue(field reflect.Value, val any) {
 	if val == nil {
 		return
 	}
@@ -455,9 +444,6 @@ func setFieldValue(field reflect.Value, val interface{}) {
 
 	// Handle pointer fields.
 	if fieldType.Kind() == reflect.Ptr {
-		if val == nil {
-			return
-		}
 		elemType := fieldType.Elem()
 		ptr := reflect.New(elemType)
 		setFieldValue(ptr.Elem(), val)

--- a/pkg/protect/model.go
+++ b/pkg/protect/model.go
@@ -1,0 +1,516 @@
+package protect
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+)
+
+// modelField holds the metadata extracted from a single struct field with a `cs` tag.
+type modelField struct {
+	// Index is the struct field index used with reflect.Value.Field().
+	Index int
+	// Column is the encryption column name from the `cs` struct tag.
+	Column string
+	// MapKey is the key used in the output map (JSON tag name or snake_case field name).
+	MapKey string
+}
+
+// modelInfo holds the pre-parsed metadata for a struct type, separating encrypted
+// fields (those with a `cs` tag) from plain fields.
+type modelInfo struct {
+	// EncryptedFields are fields with a valid `cs:"column_name"` tag.
+	EncryptedFields []modelField
+	// PlainFields are fields without a `cs` tag (or with `cs:"-"`).
+	PlainFields []modelField
+}
+
+// analyzeStruct inspects a struct type and returns its modelInfo.
+// It returns an error if typ is not a struct type.
+func analyzeStruct(typ reflect.Type) (*modelInfo, error) {
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("expected a struct type, got %s", typ.Kind())
+	}
+
+	info := &modelInfo{}
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+
+		// Skip unexported fields.
+		if !field.IsExported() {
+			continue
+		}
+
+		mapKey := fieldMapKey(field)
+		csTag, hasCS := field.Tag.Lookup("cs")
+
+		if hasCS && csTag != "-" && csTag != "" {
+			info.EncryptedFields = append(info.EncryptedFields, modelField{
+				Index:  i,
+				Column: csTag,
+				MapKey: mapKey,
+			})
+		} else {
+			info.PlainFields = append(info.PlainFields, modelField{
+				Index:  i,
+				MapKey: mapKey,
+			})
+		}
+	}
+
+	return info, nil
+}
+
+// fieldMapKey returns the map key for a struct field. It uses the JSON tag name
+// if present, otherwise converts the field name to snake_case.
+func fieldMapKey(f reflect.StructField) string {
+	if jsonTag, ok := f.Tag.Lookup("json"); ok {
+		name := strings.Split(jsonTag, ",")[0]
+		if name != "" && name != "-" {
+			return name
+		}
+	}
+	return toSnakeCase(f.Name)
+}
+
+// toSnakeCase converts a CamelCase string to snake_case.
+func toSnakeCase(s string) string {
+	var result strings.Builder
+	for i, r := range s {
+		if unicode.IsUpper(r) {
+			if i > 0 {
+				result.WriteByte('_')
+			}
+			result.WriteRune(unicode.ToLower(r))
+		} else {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}
+
+// fieldPlaintext extracts the plaintext value from a struct field, handling pointer
+// types by dereferencing them. It returns the value and whether the field is nil.
+func fieldPlaintext(v reflect.Value) (interface{}, bool) {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil, true
+		}
+		v = v.Elem()
+	}
+	return v.Interface(), false
+}
+
+// EncryptModel encrypts the tagged fields of a struct and returns a map with
+// encrypted values for `cs`-tagged fields and original values for all other fields.
+//
+// The model parameter must be a struct (or pointer to struct). The table parameter
+// identifies the table in the encryption config. Each field with a `cs:"column_name"`
+// tag is encrypted using [Client.Encrypt]. Fields without the tag are copied as-is.
+func (c *Client) EncryptModel(model interface{}, table string) (map[string]interface{}, error) {
+	v := reflect.ValueOf(model)
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil, fmt.Errorf("model must not be nil")
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("model must be a struct, got %s", v.Kind())
+	}
+
+	info, err := analyzeStruct(v.Type())
+	if err != nil {
+		return nil, fmt.Errorf("analyzing model: %w", err)
+	}
+
+	result := make(map[string]interface{}, len(info.EncryptedFields)+len(info.PlainFields))
+
+	// Copy plain fields.
+	for _, pf := range info.PlainFields {
+		result[pf.MapKey] = v.Field(pf.Index).Interface()
+	}
+
+	// Encrypt tagged fields.
+	for _, ef := range info.EncryptedFields {
+		plaintext, isNil := fieldPlaintext(v.Field(ef.Index))
+		if isNil {
+			result[ef.MapKey] = nil
+			continue
+		}
+
+		encrypted, err := c.Encrypt(EncryptOptions{
+			Plaintext: plaintext,
+			Column:    ef.Column,
+			Table:     table,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("encrypting field %q (column %q): %w", ef.MapKey, ef.Column, err)
+		}
+		result[ef.MapKey] = encrypted
+	}
+
+	return result, nil
+}
+
+// DecryptModel decrypts the encrypted fields in a map and populates the destination struct.
+//
+// The dest parameter must be a pointer to a struct. For each field in the struct with
+// a `cs:"column_name"` tag, the corresponding map value is treated as an [Encrypted]
+// payload, decrypted using [Client.Decrypt], and the resulting plaintext is set on the
+// field. Non-tagged fields are set directly from the map.
+func (c *Client) DecryptModel(data map[string]interface{}, table string, dest interface{}) error {
+	v := reflect.ValueOf(dest)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return fmt.Errorf("dest must be a non-nil pointer to a struct")
+	}
+	v = v.Elem()
+	if v.Kind() != reflect.Struct {
+		return fmt.Errorf("dest must be a pointer to a struct, got pointer to %s", v.Kind())
+	}
+
+	info, err := analyzeStruct(v.Type())
+	if err != nil {
+		return fmt.Errorf("analyzing dest: %w", err)
+	}
+
+	// Set plain fields.
+	for _, pf := range info.PlainFields {
+		rawVal, exists := data[pf.MapKey]
+		if !exists {
+			continue
+		}
+		setFieldValue(v.Field(pf.Index), rawVal)
+	}
+
+	// Decrypt tagged fields.
+	for _, ef := range info.EncryptedFields {
+		rawVal, exists := data[ef.MapKey]
+		if !exists || rawVal == nil {
+			continue
+		}
+
+		encrypted, err := toEncrypted(rawVal)
+		if err != nil {
+			return fmt.Errorf("converting field %q to Encrypted: %w", ef.MapKey, err)
+		}
+
+		plaintext, err := c.Decrypt(DecryptOptions{
+			Ciphertext: encrypted,
+		})
+		if err != nil {
+			return fmt.Errorf("decrypting field %q (column %q): %w", ef.MapKey, ef.Column, err)
+		}
+
+		setFieldValue(v.Field(ef.Index), plaintext)
+	}
+
+	return nil
+}
+
+// BulkEncryptModels encrypts multiple structs using a single bulk encryption call.
+//
+// The models parameter must be a slice of structs (or pointer to slice). Each struct's
+// `cs`-tagged fields are collected into a single call to [Client.EncryptBulk], which is
+// significantly more efficient than calling [Client.EncryptModel] for each struct individually.
+func (c *Client) BulkEncryptModels(models interface{}, table string) ([]map[string]interface{}, error) {
+	sv := reflect.ValueOf(models)
+	if sv.Kind() == reflect.Ptr {
+		if sv.IsNil() {
+			return nil, fmt.Errorf("models must not be nil")
+		}
+		sv = sv.Elem()
+	}
+	if sv.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("models must be a slice, got %s", sv.Kind())
+	}
+	if sv.Len() == 0 {
+		return []map[string]interface{}{}, nil
+	}
+
+	elemType := sv.Type().Elem()
+	if elemType.Kind() == reflect.Ptr {
+		elemType = elemType.Elem()
+	}
+
+	info, err := analyzeStruct(elemType)
+	if err != nil {
+		return nil, fmt.Errorf("analyzing model type: %w", err)
+	}
+
+	numModels := sv.Len()
+	numEncFields := len(info.EncryptedFields)
+
+	// Build bulk plaintext payloads and result maps in one pass.
+	results := make([]map[string]interface{}, numModels)
+	var payloads []PlaintextPayload
+	// Track which payloads map to which result slot; -1 for nil/skipped fields.
+	type payloadPos struct {
+		modelIdx int
+		mapKey   string
+	}
+	var positions []payloadPos
+
+	for i := 0; i < numModels; i++ {
+		elem := sv.Index(i)
+		if elem.Kind() == reflect.Ptr {
+			if elem.IsNil() {
+				results[i] = nil
+				continue
+			}
+			elem = elem.Elem()
+		}
+
+		result := make(map[string]interface{}, numEncFields+len(info.PlainFields))
+
+		// Copy plain fields.
+		for _, pf := range info.PlainFields {
+			result[pf.MapKey] = elem.Field(pf.Index).Interface()
+		}
+
+		// Collect encrypted fields.
+		for _, ef := range info.EncryptedFields {
+			plaintext, isNil := fieldPlaintext(elem.Field(ef.Index))
+			if isNil {
+				result[ef.MapKey] = nil
+				continue
+			}
+			payloads = append(payloads, PlaintextPayload{
+				Plaintext: plaintext,
+				Column:    ef.Column,
+				Table:     table,
+			})
+			positions = append(positions, payloadPos{modelIdx: i, mapKey: ef.MapKey})
+		}
+
+		results[i] = result
+	}
+
+	if len(payloads) == 0 {
+		return results, nil
+	}
+
+	encrypted, err := c.EncryptBulk(EncryptBulkOptions{
+		Plaintexts: payloads,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("bulk encrypting models: %w", err)
+	}
+
+	if len(encrypted) != len(positions) {
+		return nil, fmt.Errorf("bulk encrypt returned %d results, expected %d", len(encrypted), len(positions))
+	}
+
+	// Distribute encrypted values back.
+	for i, pos := range positions {
+		enc := encrypted[i]
+		results[pos.modelIdx][pos.mapKey] = &enc
+	}
+
+	return results, nil
+}
+
+// BulkDecryptModels decrypts multiple encrypted maps and populates a slice of structs.
+//
+// The dest parameter must be a pointer to a slice of structs. All encrypted values
+// across the maps are collected into a single call to [Client.DecryptBulk], which is
+// significantly more efficient than calling [Client.DecryptModel] for each map individually.
+func (c *Client) BulkDecryptModels(data []map[string]interface{}, table string, dest interface{}) error {
+	dv := reflect.ValueOf(dest)
+	if dv.Kind() != reflect.Ptr || dv.IsNil() {
+		return fmt.Errorf("dest must be a non-nil pointer to a slice of structs")
+	}
+	sliceVal := dv.Elem()
+	if sliceVal.Kind() != reflect.Slice {
+		return fmt.Errorf("dest must be a pointer to a slice, got pointer to %s", sliceVal.Kind())
+	}
+
+	elemType := sliceVal.Type().Elem()
+	if elemType.Kind() == reflect.Ptr {
+		elemType = elemType.Elem()
+	}
+
+	info, err := analyzeStruct(elemType)
+	if err != nil {
+		return fmt.Errorf("analyzing dest element type: %w", err)
+	}
+
+	numMaps := len(data)
+
+	// Collect all ciphertexts for bulk decryption.
+	type decryptPos struct {
+		mapIdx   int
+		fieldIdx int // index into info.EncryptedFields
+	}
+	var ciphertexts []BulkDecryptPayload
+	var positions []decryptPos
+
+	for i, m := range data {
+		for j, ef := range info.EncryptedFields {
+			rawVal, exists := m[ef.MapKey]
+			if !exists || rawVal == nil {
+				continue
+			}
+			encrypted, err := toEncrypted(rawVal)
+			if err != nil {
+				return fmt.Errorf("converting field %q in map[%d] to Encrypted: %w", ef.MapKey, i, err)
+			}
+			ciphertexts = append(ciphertexts, BulkDecryptPayload{
+				Ciphertext: encrypted,
+			})
+			positions = append(positions, decryptPos{mapIdx: i, fieldIdx: j})
+		}
+	}
+
+	// Allocate the result slice.
+	resultSlice := reflect.MakeSlice(sliceVal.Type(), numMaps, numMaps)
+
+	// Set plain fields.
+	for i, m := range data {
+		elem := resultSlice.Index(i)
+		if elem.Kind() == reflect.Ptr {
+			elem.Set(reflect.New(elemType))
+			elem = elem.Elem()
+		}
+		for _, pf := range info.PlainFields {
+			rawVal, exists := m[pf.MapKey]
+			if !exists {
+				continue
+			}
+			setFieldValue(elem.Field(pf.Index), rawVal)
+		}
+	}
+
+	// Bulk decrypt if there are any ciphertexts.
+	if len(ciphertexts) > 0 {
+		plaintexts, err := c.DecryptBulk(DecryptBulkOptions{
+			Ciphertexts: ciphertexts,
+		})
+		if err != nil {
+			return fmt.Errorf("bulk decrypting models: %w", err)
+		}
+
+		if len(plaintexts) != len(positions) {
+			return fmt.Errorf("bulk decrypt returned %d results, expected %d", len(plaintexts), len(positions))
+		}
+
+		for i, pos := range positions {
+			elem := resultSlice.Index(pos.mapIdx)
+			if elem.Kind() == reflect.Ptr {
+				elem = elem.Elem()
+			}
+			ef := info.EncryptedFields[pos.fieldIdx]
+			setFieldValue(elem.Field(ef.Index), plaintexts[i])
+		}
+	}
+
+	sliceVal.Set(resultSlice)
+	return nil
+}
+
+// toEncrypted converts a raw value (typically a map from JSON deserialization) into
+// an *Encrypted struct by marshaling to JSON and unmarshaling back.
+func toEncrypted(val interface{}) (*Encrypted, error) {
+	switch v := val.(type) {
+	case *Encrypted:
+		return v, nil
+	case Encrypted:
+		return &v, nil
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling value to JSON: %w", err)
+		}
+		var enc Encrypted
+		if err := json.Unmarshal(data, &enc); err != nil {
+			return nil, fmt.Errorf("unmarshaling value to Encrypted: %w", err)
+		}
+		return &enc, nil
+	}
+}
+
+// setFieldValue sets a struct field from an arbitrary value, handling type coercion
+// for common cases (e.g., JSON numbers to int fields, strings to string fields).
+func setFieldValue(field reflect.Value, val interface{}) {
+	if val == nil {
+		return
+	}
+
+	fieldType := field.Type()
+	valReflect := reflect.ValueOf(val)
+
+	// Handle pointer fields.
+	if fieldType.Kind() == reflect.Ptr {
+		if val == nil {
+			return
+		}
+		elemType := fieldType.Elem()
+		ptr := reflect.New(elemType)
+		setFieldValue(ptr.Elem(), val)
+		field.Set(ptr)
+		return
+	}
+
+	// Direct assignment if types are compatible.
+	if valReflect.Type().AssignableTo(fieldType) {
+		field.Set(valReflect)
+		return
+	}
+
+	// Handle type coercion for JSON-deserialized values.
+	switch fieldType.Kind() {
+	case reflect.String:
+		if s, ok := val.(string); ok {
+			field.SetString(s)
+		} else {
+			field.SetString(fmt.Sprintf("%v", val))
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch n := val.(type) {
+		case float64:
+			field.SetInt(int64(n))
+		case float32:
+			field.SetInt(int64(n))
+		case int:
+			field.SetInt(int64(n))
+		case int64:
+			field.SetInt(n)
+		case json.Number:
+			if i, err := n.Int64(); err == nil {
+				field.SetInt(i)
+			}
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		switch n := val.(type) {
+		case float64:
+			field.SetUint(uint64(n))
+		case int:
+			field.SetUint(uint64(n))
+		case uint64:
+			field.SetUint(n)
+		}
+	case reflect.Float32, reflect.Float64:
+		switch n := val.(type) {
+		case float64:
+			field.SetFloat(n)
+		case float32:
+			field.SetFloat(float64(n))
+		case int:
+			field.SetFloat(float64(n))
+		case json.Number:
+			if f, err := n.Float64(); err == nil {
+				field.SetFloat(f)
+			}
+		}
+	case reflect.Bool:
+		if b, ok := val.(bool); ok {
+			field.SetBool(b)
+		}
+	}
+}

--- a/pkg/protect/model_test.go
+++ b/pkg/protect/model_test.go
@@ -1,6 +1,7 @@
 package protect
 
 import (
+	"context"
 	"reflect"
 	"testing"
 )
@@ -60,14 +61,14 @@ func TestAnalyzeStruct(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name              string
-		typ               reflect.Type
-		wantEncrypted     int
-		wantPlain         int
-		wantErr           bool
-		encryptedColumns  []string
-		encryptedMapKeys  []string
-		plainMapKeys      []string
+		name             string
+		typ              reflect.Type
+		wantEncrypted    int
+		wantPlain        int
+		wantErr          bool
+		encryptedColumns []string
+		encryptedMapKeys []string
+		plainMapKeys     []string
 	}{
 		{
 			name:             "basic user model",
@@ -87,11 +88,11 @@ func TestAnalyzeStruct(t *testing.T) {
 			plainMapKeys:     []string{"id"},
 		},
 		{
-			name:         "no cs tags",
-			typ:          reflect.TypeOf(noCSTagModel{}),
+			name:          "no cs tags",
+			typ:           reflect.TypeOf(noCSTagModel{}),
 			wantEncrypted: 0,
-			wantPlain:    2,
-			plainMapKeys: []string{"id", "name"},
+			wantPlain:     2,
+			plainMapKeys:  []string{"id", "name"},
 		},
 		{
 			name:             "cs skip tag",
@@ -102,10 +103,10 @@ func TestAnalyzeStruct(t *testing.T) {
 			plainMapKeys:     []string{"id", "skip"},
 		},
 		{
-			name:         "empty struct",
-			typ:          reflect.TypeOf(emptyModel{}),
+			name:          "empty struct",
+			typ:           reflect.TypeOf(emptyModel{}),
 			wantEncrypted: 0,
-			wantPlain:    0,
+			wantPlain:     0,
 		},
 		{
 			name:             "pointer to struct",
@@ -453,7 +454,7 @@ func TestToEncrypted(t *testing.T) {
 		t.Parallel()
 		ct := "cipher"
 		enc := &Encrypted{
-			Identifier: NewIdentifier("users", "email"),
+			Identifier: Identifier{Table: "users", Column: "email"},
 			Version:    1,
 			Ciphertext: &ct,
 		}
@@ -470,7 +471,7 @@ func TestToEncrypted(t *testing.T) {
 		t.Parallel()
 		ct := "cipher"
 		enc := Encrypted{
-			Identifier: NewIdentifier("users", "email"),
+			Identifier: Identifier{Table: "users", Column: "email"},
 			Version:    1,
 			Ciphertext: &ct,
 		}
@@ -485,8 +486,8 @@ func TestToEncrypted(t *testing.T) {
 
 	t.Run("from map (JSON deserialized)", func(t *testing.T) {
 		t.Parallel()
-		m := map[string]interface{}{
-			"i": map[string]interface{}{
+		m := map[string]any{
+			"i": map[string]any{
 				"t": "users",
 				"c": "email",
 			},
@@ -510,8 +511,6 @@ func TestToEncrypted(t *testing.T) {
 
 	t.Run("from invalid type returns error", func(t *testing.T) {
 		t.Parallel()
-		// A string cannot be unmarshaled into Encrypted, but it can be marshaled.
-		// The unmarshal will fail because a bare string is not a JSON object.
 		_, err := toEncrypted("not-a-map")
 		if err == nil {
 			t.Fatal("expected error for invalid type")
@@ -524,12 +523,13 @@ func TestToEncrypted(t *testing.T) {
 func TestEncryptModelValidation(t *testing.T) {
 	t.Parallel()
 
-	// We use a nil client since validation happens before any FFI call.
+	ctx := context.Background()
 	c := &Client{}
+	schema := &TableDef{name: "users", columns: map[string]Column{}}
 
 	t.Run("nil model", func(t *testing.T) {
 		t.Parallel()
-		_, err := c.EncryptModel(nil, "users")
+		_, err := c.EncryptModel(ctx, schema, nil)
 		if err == nil {
 			t.Fatal("expected error for nil model")
 		}
@@ -537,7 +537,7 @@ func TestEncryptModelValidation(t *testing.T) {
 
 	t.Run("non-struct model", func(t *testing.T) {
 		t.Parallel()
-		_, err := c.EncryptModel("not a struct", "users")
+		_, err := c.EncryptModel(ctx, schema, "not a struct")
 		if err == nil {
 			t.Fatal("expected error for string model")
 		}
@@ -545,7 +545,7 @@ func TestEncryptModelValidation(t *testing.T) {
 
 	t.Run("slice model", func(t *testing.T) {
 		t.Parallel()
-		_, err := c.EncryptModel([]string{"a"}, "users")
+		_, err := c.EncryptModel(ctx, schema, []string{"a"})
 		if err == nil {
 			t.Fatal("expected error for slice model")
 		}
@@ -554,7 +554,7 @@ func TestEncryptModelValidation(t *testing.T) {
 	t.Run("nil pointer model", func(t *testing.T) {
 		t.Parallel()
 		var m *userModel
-		_, err := c.EncryptModel(m, "users")
+		_, err := c.EncryptModel(ctx, schema, m)
 		if err == nil {
 			t.Fatal("expected error for nil pointer model")
 		}
@@ -566,12 +566,14 @@ func TestEncryptModelValidation(t *testing.T) {
 func TestDecryptModelValidation(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
 	c := &Client{}
-	data := map[string]interface{}{"id": 1}
+	schema := &TableDef{name: "users", columns: map[string]Column{}}
+	data := map[string]any{"id": 1}
 
 	t.Run("nil dest", func(t *testing.T) {
 		t.Parallel()
-		err := c.DecryptModel(data, "users", nil)
+		err := c.DecryptModel(ctx, schema, data, nil)
 		if err == nil {
 			t.Fatal("expected error for nil dest")
 		}
@@ -579,7 +581,7 @@ func TestDecryptModelValidation(t *testing.T) {
 
 	t.Run("non-pointer dest", func(t *testing.T) {
 		t.Parallel()
-		err := c.DecryptModel(data, "users", userModel{})
+		err := c.DecryptModel(ctx, schema, data, userModel{})
 		if err == nil {
 			t.Fatal("expected error for non-pointer dest")
 		}
@@ -588,7 +590,7 @@ func TestDecryptModelValidation(t *testing.T) {
 	t.Run("pointer to non-struct", func(t *testing.T) {
 		t.Parallel()
 		s := "string"
-		err := c.DecryptModel(data, "users", &s)
+		err := c.DecryptModel(ctx, schema, data, &s)
 		if err == nil {
 			t.Fatal("expected error for pointer to string")
 		}
@@ -600,11 +602,13 @@ func TestDecryptModelValidation(t *testing.T) {
 func TestBulkEncryptModelsValidation(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
 	c := &Client{}
+	schema := &TableDef{name: "users", columns: map[string]Column{}}
 
 	t.Run("nil models", func(t *testing.T) {
 		t.Parallel()
-		_, err := c.BulkEncryptModels(nil, "users")
+		_, err := c.BulkEncryptModels(ctx, schema, nil)
 		if err == nil {
 			t.Fatal("expected error for nil models")
 		}
@@ -612,7 +616,7 @@ func TestBulkEncryptModelsValidation(t *testing.T) {
 
 	t.Run("non-slice models", func(t *testing.T) {
 		t.Parallel()
-		_, err := c.BulkEncryptModels("not a slice", "users")
+		_, err := c.BulkEncryptModels(ctx, schema, "not a slice")
 		if err == nil {
 			t.Fatal("expected error for non-slice models")
 		}
@@ -620,7 +624,7 @@ func TestBulkEncryptModelsValidation(t *testing.T) {
 
 	t.Run("empty slice returns empty result", func(t *testing.T) {
 		t.Parallel()
-		result, err := c.BulkEncryptModels([]userModel{}, "users")
+		result, err := c.BulkEncryptModels(ctx, schema, []userModel{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -635,12 +639,14 @@ func TestBulkEncryptModelsValidation(t *testing.T) {
 func TestBulkDecryptModelsValidation(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
 	c := &Client{}
-	data := []map[string]interface{}{{"id": 1}}
+	schema := &TableDef{name: "users", columns: map[string]Column{}}
+	data := []map[string]any{{"id": 1}}
 
 	t.Run("nil dest", func(t *testing.T) {
 		t.Parallel()
-		err := c.BulkDecryptModels(data, "users", nil)
+		err := c.BulkDecryptModels(ctx, schema, data, nil)
 		if err == nil {
 			t.Fatal("expected error for nil dest")
 		}
@@ -648,7 +654,7 @@ func TestBulkDecryptModelsValidation(t *testing.T) {
 
 	t.Run("non-pointer dest", func(t *testing.T) {
 		t.Parallel()
-		err := c.BulkDecryptModels(data, "users", []userModel{})
+		err := c.BulkDecryptModels(ctx, schema, data, []userModel{})
 		if err == nil {
 			t.Fatal("expected error for non-pointer dest")
 		}
@@ -657,14 +663,14 @@ func TestBulkDecryptModelsValidation(t *testing.T) {
 	t.Run("pointer to non-slice", func(t *testing.T) {
 		t.Parallel()
 		var u userModel
-		err := c.BulkDecryptModels(data, "users", &u)
+		err := c.BulkDecryptModels(ctx, schema, data, &u)
 		if err == nil {
 			t.Fatal("expected error for pointer to struct")
 		}
 	})
 }
 
-// --- Struct with no encrypted fields (should pass through everything) ---
+// --- Struct with no encrypted fields ---
 
 func TestAnalyzeStructNoEncryptedFields(t *testing.T) {
 	t.Parallel()
@@ -677,7 +683,6 @@ func TestAnalyzeStructNoEncryptedFields(t *testing.T) {
 	if len(info.EncryptedFields) != 0 {
 		t.Errorf("expected 0 encrypted fields, got %d", len(info.EncryptedFields))
 	}
-
 	if len(info.PlainFields) != 2 {
 		t.Errorf("expected 2 plain fields, got %d", len(info.PlainFields))
 	}
@@ -696,12 +701,10 @@ func TestAnalyzeMixedModel(t *testing.T) {
 	if len(info.EncryptedFields) != 2 {
 		t.Errorf("expected 2 encrypted fields, got %d", len(info.EncryptedFields))
 	}
-
 	if len(info.PlainFields) != 3 {
 		t.Errorf("expected 3 plain fields (id, active, balance), got %d", len(info.PlainFields))
 	}
 
-	// Verify the encrypted fields are the correct ones.
 	expectedColumns := map[string]bool{"email": true, "name": true}
 	for _, ef := range info.EncryptedFields {
 		if !expectedColumns[ef.Column] {
@@ -720,16 +723,13 @@ func TestCSSkipTag(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// The Skip field with cs:"-" should be in PlainFields, not EncryptedFields.
 	if len(info.EncryptedFields) != 1 {
 		t.Errorf("expected 1 encrypted field, got %d", len(info.EncryptedFields))
 	}
-
 	if info.EncryptedFields[0].Column != "email" {
 		t.Errorf("expected encrypted column %q, got %q", "email", info.EncryptedFields[0].Column)
 	}
 
-	// PlainFields should be: ID and Skip
 	if len(info.PlainFields) != 2 {
 		t.Errorf("expected 2 plain fields, got %d", len(info.PlainFields))
 	}
@@ -764,8 +764,6 @@ func TestJSONTagWithOptions(t *testing.T) {
 	if len(info.EncryptedFields) != 1 {
 		t.Fatalf("expected 1 encrypted field, got %d", len(info.EncryptedFields))
 	}
-
-	// The map key should use the name part of the JSON tag, not the options.
 	if info.EncryptedFields[0].MapKey != "email" {
 		t.Errorf("map key: got %q, want %q", info.EncryptedFields[0].MapKey, "email")
 	}
@@ -773,13 +771,12 @@ func TestJSONTagWithOptions(t *testing.T) {
 	if len(info.PlainFields) != 1 {
 		t.Fatalf("expected 1 plain field, got %d", len(info.PlainFields))
 	}
-
 	if info.PlainFields[0].MapKey != "id" {
 		t.Errorf("map key: got %q, want %q", info.PlainFields[0].MapKey, "id")
 	}
 }
 
-// --- Test setFieldValue with various real struct scenarios ---
+// --- Test setFieldValue on struct ---
 
 func TestSetFieldValueOnStruct(t *testing.T) {
 	t.Parallel()
@@ -789,7 +786,7 @@ func TestSetFieldValueOnStruct(t *testing.T) {
 		var u userModel
 		v := reflect.ValueOf(&u).Elem()
 
-		setFieldValue(v.Field(0), float64(1)) // ID - float64 from JSON
+		setFieldValue(v.Field(0), float64(1)) // ID
 		setFieldValue(v.Field(3), "admin")    // Role
 
 		if u.ID != 1 {
@@ -805,7 +802,7 @@ func TestSetFieldValueOnStruct(t *testing.T) {
 		var m pointerFieldModel
 		v := reflect.ValueOf(&m).Elem()
 
-		setFieldValue(v.Field(0), float64(2))    // ID
+		setFieldValue(v.Field(0), float64(2))      // ID
 		setFieldValue(v.Field(1), "test@test.com") // Email *string
 
 		if m.ID != 2 {
@@ -838,13 +835,12 @@ func TestEmptyCSTag(t *testing.T) {
 	if len(info.EncryptedFields) != 0 {
 		t.Errorf("expected 0 encrypted fields for empty cs tag, got %d", len(info.EncryptedFields))
 	}
-
 	if len(info.PlainFields) != 2 {
 		t.Errorf("expected 2 plain fields, got %d", len(info.PlainFields))
 	}
 }
 
-// --- Test JSON tag "-" means field is excluded from JSON but still tracked as plain ---
+// --- Test JSON tag "-" means field falls back to snake_case ---
 
 type jsonSkipModel struct {
 	ID     int    `json:"-"`
@@ -860,12 +856,10 @@ func TestJSONSkipTag(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// ID and Hidden have json:"-", so fieldMapKey falls back to snake_case.
 	if len(info.PlainFields) != 2 {
 		t.Fatalf("expected 2 plain fields, got %d", len(info.PlainFields))
 	}
 
-	// With json:"-", the name part is "-", which we reject, so it falls back to snake_case.
 	if info.PlainFields[0].MapKey != "i_d" {
 		t.Errorf("ID map key: got %q, want %q", info.PlainFields[0].MapKey, "i_d")
 	}

--- a/pkg/protect/model_test.go
+++ b/pkg/protect/model_test.go
@@ -2,6 +2,7 @@ package protect
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -518,156 +519,71 @@ func TestToEncrypted(t *testing.T) {
 	})
 }
 
-// --- Input validation tests for EncryptModel ---
+// --- Client closed tests for model methods ---
 
-func TestEncryptModelValidation(t *testing.T) {
+func TestEncryptModelClientClosed(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	c := &Client{}
+	c := &Client{} // ptr is nil — simulates a closed client
 	schema := &TableDef{name: "users", columns: map[string]Column{}}
 
-	t.Run("nil model", func(t *testing.T) {
-		t.Parallel()
-		_, err := c.EncryptModel(ctx, schema, nil)
-		if err == nil {
-			t.Fatal("expected error for nil model")
-		}
-	})
-
-	t.Run("non-struct model", func(t *testing.T) {
-		t.Parallel()
-		_, err := c.EncryptModel(ctx, schema, "not a struct")
-		if err == nil {
-			t.Fatal("expected error for string model")
-		}
-	})
-
-	t.Run("slice model", func(t *testing.T) {
-		t.Parallel()
-		_, err := c.EncryptModel(ctx, schema, []string{"a"})
-		if err == nil {
-			t.Fatal("expected error for slice model")
-		}
-	})
-
-	t.Run("nil pointer model", func(t *testing.T) {
-		t.Parallel()
-		var m *userModel
-		_, err := c.EncryptModel(ctx, schema, m)
-		if err == nil {
-			t.Fatal("expected error for nil pointer model")
-		}
-	})
+	_, err := c.EncryptModel(ctx, schema, userModel{})
+	if err == nil {
+		t.Fatal("expected error for closed client")
+	}
+	if !errors.Is(err, ErrClientClosed) {
+		t.Errorf("expected ErrClientClosed, got: %v", err)
+	}
 }
 
-// --- Input validation tests for DecryptModel ---
-
-func TestDecryptModelValidation(t *testing.T) {
+func TestDecryptModelClientClosed(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	c := &Client{}
 	schema := &TableDef{name: "users", columns: map[string]Column{}}
-	data := map[string]any{"id": 1}
 
-	t.Run("nil dest", func(t *testing.T) {
-		t.Parallel()
-		err := c.DecryptModel(ctx, schema, data, nil)
-		if err == nil {
-			t.Fatal("expected error for nil dest")
-		}
-	})
-
-	t.Run("non-pointer dest", func(t *testing.T) {
-		t.Parallel()
-		err := c.DecryptModel(ctx, schema, data, userModel{})
-		if err == nil {
-			t.Fatal("expected error for non-pointer dest")
-		}
-	})
-
-	t.Run("pointer to non-struct", func(t *testing.T) {
-		t.Parallel()
-		s := "string"
-		err := c.DecryptModel(ctx, schema, data, &s)
-		if err == nil {
-			t.Fatal("expected error for pointer to string")
-		}
-	})
+	err := c.DecryptModel(ctx, schema, map[string]any{"id": 1}, &userModel{})
+	if err == nil {
+		t.Fatal("expected error for closed client")
+	}
+	if !errors.Is(err, ErrClientClosed) {
+		t.Errorf("expected ErrClientClosed, got: %v", err)
+	}
 }
 
-// --- Input validation tests for BulkEncryptModels ---
-
-func TestBulkEncryptModelsValidation(t *testing.T) {
+func TestBulkEncryptModelsClientClosed(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	c := &Client{}
 	schema := &TableDef{name: "users", columns: map[string]Column{}}
 
-	t.Run("nil models", func(t *testing.T) {
-		t.Parallel()
-		_, err := c.BulkEncryptModels(ctx, schema, nil)
-		if err == nil {
-			t.Fatal("expected error for nil models")
-		}
-	})
-
-	t.Run("non-slice models", func(t *testing.T) {
-		t.Parallel()
-		_, err := c.BulkEncryptModels(ctx, schema, "not a slice")
-		if err == nil {
-			t.Fatal("expected error for non-slice models")
-		}
-	})
-
-	t.Run("empty slice returns empty result", func(t *testing.T) {
-		t.Parallel()
-		result, err := c.BulkEncryptModels(ctx, schema, []userModel{})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(result) != 0 {
-			t.Errorf("expected empty result, got %d items", len(result))
-		}
-	})
+	_, err := c.BulkEncryptModels(ctx, schema, []userModel{{ID: 1}})
+	if err == nil {
+		t.Fatal("expected error for closed client")
+	}
+	if !errors.Is(err, ErrClientClosed) {
+		t.Errorf("expected ErrClientClosed, got: %v", err)
+	}
 }
 
-// --- Input validation tests for BulkDecryptModels ---
-
-func TestBulkDecryptModelsValidation(t *testing.T) {
+func TestBulkDecryptModelsClientClosed(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	c := &Client{}
 	schema := &TableDef{name: "users", columns: map[string]Column{}}
-	data := []map[string]any{{"id": 1}}
 
-	t.Run("nil dest", func(t *testing.T) {
-		t.Parallel()
-		err := c.BulkDecryptModels(ctx, schema, data, nil)
-		if err == nil {
-			t.Fatal("expected error for nil dest")
-		}
-	})
-
-	t.Run("non-pointer dest", func(t *testing.T) {
-		t.Parallel()
-		err := c.BulkDecryptModels(ctx, schema, data, []userModel{})
-		if err == nil {
-			t.Fatal("expected error for non-pointer dest")
-		}
-	})
-
-	t.Run("pointer to non-slice", func(t *testing.T) {
-		t.Parallel()
-		var u userModel
-		err := c.BulkDecryptModels(ctx, schema, data, &u)
-		if err == nil {
-			t.Fatal("expected error for pointer to struct")
-		}
-	})
+	var users []userModel
+	err := c.BulkDecryptModels(ctx, schema, []map[string]any{{"id": 1}}, &users)
+	if err == nil {
+		t.Fatal("expected error for closed client")
+	}
+	if !errors.Is(err, ErrClientClosed) {
+		t.Errorf("expected ErrClientClosed, got: %v", err)
+	}
 }
 
 // --- Struct with no encrypted fields ---

--- a/pkg/protect/model_test.go
+++ b/pkg/protect/model_test.go
@@ -1,0 +1,875 @@
+package protect
+
+import (
+	"reflect"
+	"testing"
+)
+
+// --- Test structs used across multiple tests ---
+
+type userModel struct {
+	ID    int    `json:"id"`
+	Email string `json:"email" cs:"email"`
+	Name  string `json:"name" cs:"name"`
+	Role  string `json:"role"`
+}
+
+type pointerFieldModel struct {
+	ID    int     `json:"id"`
+	Email *string `json:"email" cs:"email"`
+	Name  *string `json:"name" cs:"name"`
+}
+
+type noCSTagModel struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type skipFieldModel struct {
+	ID    int    `json:"id"`
+	Email string `json:"email" cs:"email"`
+	Skip  string `json:"skip" cs:"-"`
+}
+
+type noJSONTagModel struct {
+	ID        int
+	FirstName string `cs:"first_name"`
+	LastName  string
+}
+
+type mixedModel struct {
+	ID      int     `json:"id"`
+	Email   string  `json:"email" cs:"email"`
+	Name    *string `json:"name" cs:"name"`
+	Active  bool    `json:"active"`
+	Balance float64 `json:"balance"`
+}
+
+type emptyModel struct{}
+
+type unexportedFieldModel struct {
+	ID    int    `json:"id"`
+	Email string `json:"email" cs:"email"`
+	// unexported fields should be skipped
+	secret string //nolint:unused
+}
+
+// --- analyzeStruct tests ---
+
+func TestAnalyzeStruct(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		typ               reflect.Type
+		wantEncrypted     int
+		wantPlain         int
+		wantErr           bool
+		encryptedColumns  []string
+		encryptedMapKeys  []string
+		plainMapKeys      []string
+	}{
+		{
+			name:             "basic user model",
+			typ:              reflect.TypeOf(userModel{}),
+			wantEncrypted:    2,
+			wantPlain:        2,
+			encryptedColumns: []string{"email", "name"},
+			encryptedMapKeys: []string{"email", "name"},
+			plainMapKeys:     []string{"id", "role"},
+		},
+		{
+			name:             "pointer fields",
+			typ:              reflect.TypeOf(pointerFieldModel{}),
+			wantEncrypted:    2,
+			wantPlain:        1,
+			encryptedColumns: []string{"email", "name"},
+			plainMapKeys:     []string{"id"},
+		},
+		{
+			name:         "no cs tags",
+			typ:          reflect.TypeOf(noCSTagModel{}),
+			wantEncrypted: 0,
+			wantPlain:    2,
+			plainMapKeys: []string{"id", "name"},
+		},
+		{
+			name:             "cs skip tag",
+			typ:              reflect.TypeOf(skipFieldModel{}),
+			wantEncrypted:    1,
+			wantPlain:        2,
+			encryptedColumns: []string{"email"},
+			plainMapKeys:     []string{"id", "skip"},
+		},
+		{
+			name:         "empty struct",
+			typ:          reflect.TypeOf(emptyModel{}),
+			wantEncrypted: 0,
+			wantPlain:    0,
+		},
+		{
+			name:             "pointer to struct",
+			typ:              reflect.TypeOf(&userModel{}),
+			wantEncrypted:    2,
+			wantPlain:        2,
+			encryptedColumns: []string{"email", "name"},
+		},
+		{
+			name:             "unexported fields skipped",
+			typ:              reflect.TypeOf(unexportedFieldModel{}),
+			wantEncrypted:    1,
+			wantPlain:        1,
+			encryptedColumns: []string{"email"},
+			plainMapKeys:     []string{"id"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			info, err := analyzeStruct(tc.typ)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(info.EncryptedFields) != tc.wantEncrypted {
+				t.Errorf("encrypted fields: got %d, want %d", len(info.EncryptedFields), tc.wantEncrypted)
+			}
+			if len(info.PlainFields) != tc.wantPlain {
+				t.Errorf("plain fields: got %d, want %d", len(info.PlainFields), tc.wantPlain)
+			}
+
+			for i, col := range tc.encryptedColumns {
+				if i < len(info.EncryptedFields) && info.EncryptedFields[i].Column != col {
+					t.Errorf("encrypted field %d: column got %q, want %q", i, info.EncryptedFields[i].Column, col)
+				}
+			}
+			for i, key := range tc.encryptedMapKeys {
+				if i < len(info.EncryptedFields) && info.EncryptedFields[i].MapKey != key {
+					t.Errorf("encrypted field %d: map key got %q, want %q", i, info.EncryptedFields[i].MapKey, key)
+				}
+			}
+			for i, key := range tc.plainMapKeys {
+				if i < len(info.PlainFields) && info.PlainFields[i].MapKey != key {
+					t.Errorf("plain field %d: map key got %q, want %q", i, info.PlainFields[i].MapKey, key)
+				}
+			}
+		})
+	}
+}
+
+func TestAnalyzeStructRejectsNonStruct(t *testing.T) {
+	t.Parallel()
+
+	_, err := analyzeStruct(reflect.TypeOf("not a struct"))
+	if err == nil {
+		t.Fatal("expected error for non-struct type")
+	}
+
+	_, err = analyzeStruct(reflect.TypeOf(42))
+	if err == nil {
+		t.Fatal("expected error for int type")
+	}
+
+	_, err = analyzeStruct(reflect.TypeOf([]string{}))
+	if err == nil {
+		t.Fatal("expected error for slice type")
+	}
+}
+
+// --- fieldMapKey tests ---
+
+func TestFieldMapKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		typ      reflect.Type
+		fieldIdx int
+		want     string
+	}{
+		{
+			name:     "json tag present",
+			typ:      reflect.TypeOf(userModel{}),
+			fieldIdx: 0, // ID field with json:"id"
+			want:     "id",
+		},
+		{
+			name:     "no json tag uses snake_case",
+			typ:      reflect.TypeOf(noJSONTagModel{}),
+			fieldIdx: 0, // ID field with no json tag
+			want:     "i_d",
+		},
+		{
+			name:     "camel case to snake_case",
+			typ:      reflect.TypeOf(noJSONTagModel{}),
+			fieldIdx: 1, // FirstName field with cs but no json tag
+			want:     "first_name",
+		},
+		{
+			name:     "simple lowercase",
+			typ:      reflect.TypeOf(noJSONTagModel{}),
+			fieldIdx: 2, // LastName field
+			want:     "last_name",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			field := tc.typ.Field(tc.fieldIdx)
+			got := fieldMapKey(field)
+			if got != tc.want {
+				t.Errorf("fieldMapKey(%s) = %q, want %q", field.Name, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- toSnakeCase tests ---
+
+func TestToSnakeCase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"ID", "i_d"},
+		{"FirstName", "first_name"},
+		{"lastName", "last_name"},
+		{"email", "email"},
+		{"HTMLParser", "h_t_m_l_parser"},
+		{"A", "a"},
+		{"", ""},
+		{"alreadylower", "alreadylower"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := toSnakeCase(tc.input)
+			if got != tc.want {
+				t.Errorf("toSnakeCase(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- fieldPlaintext tests ---
+
+func TestFieldPlaintext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("direct string value", func(t *testing.T) {
+		t.Parallel()
+		v := reflect.ValueOf("hello")
+		val, isNil := fieldPlaintext(v)
+		if isNil {
+			t.Fatal("expected non-nil")
+		}
+		if val != "hello" {
+			t.Errorf("got %v, want %q", val, "hello")
+		}
+	})
+
+	t.Run("direct int value", func(t *testing.T) {
+		t.Parallel()
+		v := reflect.ValueOf(42)
+		val, isNil := fieldPlaintext(v)
+		if isNil {
+			t.Fatal("expected non-nil")
+		}
+		if val != 42 {
+			t.Errorf("got %v, want 42", val)
+		}
+	})
+
+	t.Run("non-nil pointer", func(t *testing.T) {
+		t.Parallel()
+		s := "world"
+		v := reflect.ValueOf(&s)
+		val, isNil := fieldPlaintext(v)
+		if isNil {
+			t.Fatal("expected non-nil")
+		}
+		if val != "world" {
+			t.Errorf("got %v, want %q", val, "world")
+		}
+	})
+
+	t.Run("nil pointer", func(t *testing.T) {
+		t.Parallel()
+		var s *string
+		v := reflect.ValueOf(s)
+		_, isNil := fieldPlaintext(v)
+		if !isNil {
+			t.Fatal("expected nil")
+		}
+	})
+
+	t.Run("bool value", func(t *testing.T) {
+		t.Parallel()
+		v := reflect.ValueOf(true)
+		val, isNil := fieldPlaintext(v)
+		if isNil {
+			t.Fatal("expected non-nil")
+		}
+		if val != true {
+			t.Errorf("got %v, want true", val)
+		}
+	})
+
+	t.Run("float value", func(t *testing.T) {
+		t.Parallel()
+		v := reflect.ValueOf(3.14)
+		val, isNil := fieldPlaintext(v)
+		if isNil {
+			t.Fatal("expected non-nil")
+		}
+		if val != 3.14 {
+			t.Errorf("got %v, want 3.14", val)
+		}
+	})
+}
+
+// --- setFieldValue tests ---
+
+func TestSetFieldValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("string to string", func(t *testing.T) {
+		t.Parallel()
+		var s string
+		v := reflect.ValueOf(&s).Elem()
+		setFieldValue(v, "hello")
+		if s != "hello" {
+			t.Errorf("got %q, want %q", s, "hello")
+		}
+	})
+
+	t.Run("float64 to int", func(t *testing.T) {
+		t.Parallel()
+		var i int
+		v := reflect.ValueOf(&i).Elem()
+		setFieldValue(v, float64(42))
+		if i != 42 {
+			t.Errorf("got %d, want 42", i)
+		}
+	})
+
+	t.Run("float64 to float64", func(t *testing.T) {
+		t.Parallel()
+		var f float64
+		v := reflect.ValueOf(&f).Elem()
+		setFieldValue(v, float64(3.14))
+		if f != 3.14 {
+			t.Errorf("got %f, want 3.14", f)
+		}
+	})
+
+	t.Run("bool to bool", func(t *testing.T) {
+		t.Parallel()
+		var b bool
+		v := reflect.ValueOf(&b).Elem()
+		setFieldValue(v, true)
+		if !b {
+			t.Error("got false, want true")
+		}
+	})
+
+	t.Run("string to pointer string", func(t *testing.T) {
+		t.Parallel()
+		var s *string
+		v := reflect.ValueOf(&s).Elem()
+		setFieldValue(v, "world")
+		if s == nil {
+			t.Fatal("got nil pointer")
+		}
+		if *s != "world" {
+			t.Errorf("got %q, want %q", *s, "world")
+		}
+	})
+
+	t.Run("nil value is no-op", func(t *testing.T) {
+		t.Parallel()
+		s := "original"
+		v := reflect.ValueOf(&s).Elem()
+		setFieldValue(v, nil)
+		if s != "original" {
+			t.Errorf("got %q, want %q", s, "original")
+		}
+	})
+
+	t.Run("int to int", func(t *testing.T) {
+		t.Parallel()
+		var i int
+		v := reflect.ValueOf(&i).Elem()
+		setFieldValue(v, int(7))
+		if i != 7 {
+			t.Errorf("got %d, want 7", i)
+		}
+	})
+
+	t.Run("float64 to uint", func(t *testing.T) {
+		t.Parallel()
+		var u uint
+		v := reflect.ValueOf(&u).Elem()
+		setFieldValue(v, float64(100))
+		if u != 100 {
+			t.Errorf("got %d, want 100", u)
+		}
+	})
+
+	t.Run("non-string to string via format", func(t *testing.T) {
+		t.Parallel()
+		var s string
+		v := reflect.ValueOf(&s).Elem()
+		setFieldValue(v, 42)
+		if s != "42" {
+			t.Errorf("got %q, want %q", s, "42")
+		}
+	})
+}
+
+// --- toEncrypted tests ---
+
+func TestToEncrypted(t *testing.T) {
+	t.Parallel()
+
+	t.Run("from *Encrypted", func(t *testing.T) {
+		t.Parallel()
+		ct := "cipher"
+		enc := &Encrypted{
+			Identifier: NewIdentifier("users", "email"),
+			Version:    1,
+			Ciphertext: &ct,
+		}
+		result, err := toEncrypted(enc)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != enc {
+			t.Error("expected same pointer back")
+		}
+	})
+
+	t.Run("from Encrypted value", func(t *testing.T) {
+		t.Parallel()
+		ct := "cipher"
+		enc := Encrypted{
+			Identifier: NewIdentifier("users", "email"),
+			Version:    1,
+			Ciphertext: &ct,
+		}
+		result, err := toEncrypted(enc)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if *result.Ciphertext != "cipher" {
+			t.Errorf("ciphertext: got %q, want %q", *result.Ciphertext, "cipher")
+		}
+	})
+
+	t.Run("from map (JSON deserialized)", func(t *testing.T) {
+		t.Parallel()
+		m := map[string]interface{}{
+			"i": map[string]interface{}{
+				"t": "users",
+				"c": "email",
+			},
+			"v": float64(1),
+			"c": "encrypted-data",
+		}
+		result, err := toEncrypted(m)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Identifier.Table != "users" {
+			t.Errorf("table: got %q, want %q", result.Identifier.Table, "users")
+		}
+		if result.Identifier.Column != "email" {
+			t.Errorf("column: got %q, want %q", result.Identifier.Column, "email")
+		}
+		if result.Ciphertext == nil || *result.Ciphertext != "encrypted-data" {
+			t.Errorf("ciphertext: got %v, want %q", result.Ciphertext, "encrypted-data")
+		}
+	})
+
+	t.Run("from invalid type returns error", func(t *testing.T) {
+		t.Parallel()
+		// A string cannot be unmarshaled into Encrypted, but it can be marshaled.
+		// The unmarshal will fail because a bare string is not a JSON object.
+		_, err := toEncrypted("not-a-map")
+		if err == nil {
+			t.Fatal("expected error for invalid type")
+		}
+	})
+}
+
+// --- Input validation tests for EncryptModel ---
+
+func TestEncryptModelValidation(t *testing.T) {
+	t.Parallel()
+
+	// We use a nil client since validation happens before any FFI call.
+	c := &Client{}
+
+	t.Run("nil model", func(t *testing.T) {
+		t.Parallel()
+		_, err := c.EncryptModel(nil, "users")
+		if err == nil {
+			t.Fatal("expected error for nil model")
+		}
+	})
+
+	t.Run("non-struct model", func(t *testing.T) {
+		t.Parallel()
+		_, err := c.EncryptModel("not a struct", "users")
+		if err == nil {
+			t.Fatal("expected error for string model")
+		}
+	})
+
+	t.Run("slice model", func(t *testing.T) {
+		t.Parallel()
+		_, err := c.EncryptModel([]string{"a"}, "users")
+		if err == nil {
+			t.Fatal("expected error for slice model")
+		}
+	})
+
+	t.Run("nil pointer model", func(t *testing.T) {
+		t.Parallel()
+		var m *userModel
+		_, err := c.EncryptModel(m, "users")
+		if err == nil {
+			t.Fatal("expected error for nil pointer model")
+		}
+	})
+}
+
+// --- Input validation tests for DecryptModel ---
+
+func TestDecryptModelValidation(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{}
+	data := map[string]interface{}{"id": 1}
+
+	t.Run("nil dest", func(t *testing.T) {
+		t.Parallel()
+		err := c.DecryptModel(data, "users", nil)
+		if err == nil {
+			t.Fatal("expected error for nil dest")
+		}
+	})
+
+	t.Run("non-pointer dest", func(t *testing.T) {
+		t.Parallel()
+		err := c.DecryptModel(data, "users", userModel{})
+		if err == nil {
+			t.Fatal("expected error for non-pointer dest")
+		}
+	})
+
+	t.Run("pointer to non-struct", func(t *testing.T) {
+		t.Parallel()
+		s := "string"
+		err := c.DecryptModel(data, "users", &s)
+		if err == nil {
+			t.Fatal("expected error for pointer to string")
+		}
+	})
+}
+
+// --- Input validation tests for BulkEncryptModels ---
+
+func TestBulkEncryptModelsValidation(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{}
+
+	t.Run("nil models", func(t *testing.T) {
+		t.Parallel()
+		_, err := c.BulkEncryptModels(nil, "users")
+		if err == nil {
+			t.Fatal("expected error for nil models")
+		}
+	})
+
+	t.Run("non-slice models", func(t *testing.T) {
+		t.Parallel()
+		_, err := c.BulkEncryptModels("not a slice", "users")
+		if err == nil {
+			t.Fatal("expected error for non-slice models")
+		}
+	})
+
+	t.Run("empty slice returns empty result", func(t *testing.T) {
+		t.Parallel()
+		result, err := c.BulkEncryptModels([]userModel{}, "users")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got %d items", len(result))
+		}
+	})
+}
+
+// --- Input validation tests for BulkDecryptModels ---
+
+func TestBulkDecryptModelsValidation(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{}
+	data := []map[string]interface{}{{"id": 1}}
+
+	t.Run("nil dest", func(t *testing.T) {
+		t.Parallel()
+		err := c.BulkDecryptModels(data, "users", nil)
+		if err == nil {
+			t.Fatal("expected error for nil dest")
+		}
+	})
+
+	t.Run("non-pointer dest", func(t *testing.T) {
+		t.Parallel()
+		err := c.BulkDecryptModels(data, "users", []userModel{})
+		if err == nil {
+			t.Fatal("expected error for non-pointer dest")
+		}
+	})
+
+	t.Run("pointer to non-slice", func(t *testing.T) {
+		t.Parallel()
+		var u userModel
+		err := c.BulkDecryptModels(data, "users", &u)
+		if err == nil {
+			t.Fatal("expected error for pointer to struct")
+		}
+	})
+}
+
+// --- Struct with no encrypted fields (should pass through everything) ---
+
+func TestAnalyzeStructNoEncryptedFields(t *testing.T) {
+	t.Parallel()
+
+	info, err := analyzeStruct(reflect.TypeOf(noCSTagModel{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(info.EncryptedFields) != 0 {
+		t.Errorf("expected 0 encrypted fields, got %d", len(info.EncryptedFields))
+	}
+
+	if len(info.PlainFields) != 2 {
+		t.Errorf("expected 2 plain fields, got %d", len(info.PlainFields))
+	}
+}
+
+// --- Mixed field types ---
+
+func TestAnalyzeMixedModel(t *testing.T) {
+	t.Parallel()
+
+	info, err := analyzeStruct(reflect.TypeOf(mixedModel{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(info.EncryptedFields) != 2 {
+		t.Errorf("expected 2 encrypted fields, got %d", len(info.EncryptedFields))
+	}
+
+	if len(info.PlainFields) != 3 {
+		t.Errorf("expected 3 plain fields (id, active, balance), got %d", len(info.PlainFields))
+	}
+
+	// Verify the encrypted fields are the correct ones.
+	expectedColumns := map[string]bool{"email": true, "name": true}
+	for _, ef := range info.EncryptedFields {
+		if !expectedColumns[ef.Column] {
+			t.Errorf("unexpected encrypted column: %q", ef.Column)
+		}
+	}
+}
+
+// --- Test that cs:"-" fields end up as plain fields ---
+
+func TestCSSkipTag(t *testing.T) {
+	t.Parallel()
+
+	info, err := analyzeStruct(reflect.TypeOf(skipFieldModel{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The Skip field with cs:"-" should be in PlainFields, not EncryptedFields.
+	if len(info.EncryptedFields) != 1 {
+		t.Errorf("expected 1 encrypted field, got %d", len(info.EncryptedFields))
+	}
+
+	if info.EncryptedFields[0].Column != "email" {
+		t.Errorf("expected encrypted column %q, got %q", "email", info.EncryptedFields[0].Column)
+	}
+
+	// PlainFields should be: ID and Skip
+	if len(info.PlainFields) != 2 {
+		t.Errorf("expected 2 plain fields, got %d", len(info.PlainFields))
+	}
+
+	plainKeys := make(map[string]bool)
+	for _, pf := range info.PlainFields {
+		plainKeys[pf.MapKey] = true
+	}
+	if !plainKeys["id"] {
+		t.Error("expected 'id' in plain fields")
+	}
+	if !plainKeys["skip"] {
+		t.Error("expected 'skip' in plain fields")
+	}
+}
+
+// --- Test JSON tag with options like omitempty ---
+
+type jsonOptsModel struct {
+	ID    int    `json:"id,omitempty"`
+	Email string `json:"email,omitempty" cs:"email"`
+}
+
+func TestJSONTagWithOptions(t *testing.T) {
+	t.Parallel()
+
+	info, err := analyzeStruct(reflect.TypeOf(jsonOptsModel{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(info.EncryptedFields) != 1 {
+		t.Fatalf("expected 1 encrypted field, got %d", len(info.EncryptedFields))
+	}
+
+	// The map key should use the name part of the JSON tag, not the options.
+	if info.EncryptedFields[0].MapKey != "email" {
+		t.Errorf("map key: got %q, want %q", info.EncryptedFields[0].MapKey, "email")
+	}
+
+	if len(info.PlainFields) != 1 {
+		t.Fatalf("expected 1 plain field, got %d", len(info.PlainFields))
+	}
+
+	if info.PlainFields[0].MapKey != "id" {
+		t.Errorf("map key: got %q, want %q", info.PlainFields[0].MapKey, "id")
+	}
+}
+
+// --- Test setFieldValue with various real struct scenarios ---
+
+func TestSetFieldValueOnStruct(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populate user from map values", func(t *testing.T) {
+		t.Parallel()
+		var u userModel
+		v := reflect.ValueOf(&u).Elem()
+
+		setFieldValue(v.Field(0), float64(1)) // ID - float64 from JSON
+		setFieldValue(v.Field(3), "admin")    // Role
+
+		if u.ID != 1 {
+			t.Errorf("ID: got %d, want 1", u.ID)
+		}
+		if u.Role != "admin" {
+			t.Errorf("Role: got %q, want %q", u.Role, "admin")
+		}
+	})
+
+	t.Run("populate pointer fields", func(t *testing.T) {
+		t.Parallel()
+		var m pointerFieldModel
+		v := reflect.ValueOf(&m).Elem()
+
+		setFieldValue(v.Field(0), float64(2))    // ID
+		setFieldValue(v.Field(1), "test@test.com") // Email *string
+
+		if m.ID != 2 {
+			t.Errorf("ID: got %d, want 2", m.ID)
+		}
+		if m.Email == nil {
+			t.Fatal("Email: got nil pointer")
+		}
+		if *m.Email != "test@test.com" {
+			t.Errorf("Email: got %q, want %q", *m.Email, "test@test.com")
+		}
+	})
+}
+
+// --- Test empty cs tag is treated as plain field ---
+
+type emptyCSTagModel struct {
+	ID    int    `json:"id"`
+	Email string `json:"email" cs:""`
+}
+
+func TestEmptyCSTag(t *testing.T) {
+	t.Parallel()
+
+	info, err := analyzeStruct(reflect.TypeOf(emptyCSTagModel{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(info.EncryptedFields) != 0 {
+		t.Errorf("expected 0 encrypted fields for empty cs tag, got %d", len(info.EncryptedFields))
+	}
+
+	if len(info.PlainFields) != 2 {
+		t.Errorf("expected 2 plain fields, got %d", len(info.PlainFields))
+	}
+}
+
+// --- Test JSON tag "-" means field is excluded from JSON but still tracked as plain ---
+
+type jsonSkipModel struct {
+	ID     int    `json:"-"`
+	Email  string `json:"email" cs:"email"`
+	Hidden string `json:"-"`
+}
+
+func TestJSONSkipTag(t *testing.T) {
+	t.Parallel()
+
+	info, err := analyzeStruct(reflect.TypeOf(jsonSkipModel{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// ID and Hidden have json:"-", so fieldMapKey falls back to snake_case.
+	if len(info.PlainFields) != 2 {
+		t.Fatalf("expected 2 plain fields, got %d", len(info.PlainFields))
+	}
+
+	// With json:"-", the name part is "-", which we reject, so it falls back to snake_case.
+	if info.PlainFields[0].MapKey != "i_d" {
+		t.Errorf("ID map key: got %q, want %q", info.PlainFields[0].MapKey, "i_d")
+	}
+	if info.PlainFields[1].MapKey != "hidden" {
+		t.Errorf("Hidden map key: got %q, want %q", info.PlainFields[1].MapKey, "hidden")
+	}
+}

--- a/pkg/protect/protect.go
+++ b/pkg/protect/protect.go
@@ -1,3 +1,13 @@
+// Package protect provides field-level encryption with searchable encryption support.
+//
+// Define your schema using struct tags or the programmatic builder, then use
+// the Client to encrypt, decrypt, and query encrypted data.
+//
+//	users, err := protect.TableSchema("users", User{})
+//	client, err := protect.NewClient(ctx, protect.WithSchemas(users))
+//	defer client.Close()
+//
+//	encrypted, err := client.Encrypt(ctx, users.Column("email"), "john@example.com")
 package protect
 
 /*
@@ -14,17 +24,65 @@ package protect
 */
 import "C"
 import (
+	"context"
 	"encoding/json"
-	"strings"
 	"unsafe"
 )
 
-// Client represents a protect FFI client.
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+// Client is the main entry point for encryption and decryption operations.
+// Create one with NewClient and release resources with Close.
 type Client struct {
 	ptr unsafe.Pointer
 }
 
-// CastAs represents the different data types for column casting
+// Close releases resources held by the client. Implements io.Closer.
+// It is safe to call Close multiple times.
+func (c *Client) Close() error {
+	if c.ptr == nil {
+		return nil
+	}
+	C.protect_free_client((*C.struct_Client)(c.ptr))
+	c.ptr = nil
+	return nil
+}
+
+// ColumnRef is a reference to an encrypted column within a table schema.
+// Created by TableDef.Column; carries the table and column names for use
+// in Encrypt, Decrypt, and query operations.
+type ColumnRef struct {
+	table  string
+	column string
+}
+
+// QueryType identifies the type of encrypted search to perform.
+type QueryType string
+
+const (
+	// Equality produces a unique (HMAC) index for exact-match lookups.
+	Equality QueryType = "unique"
+
+	// FreeTextSearch produces a match (bloom filter) index for full-text search.
+	FreeTextSearch QueryType = "match"
+
+	// OrderAndRange produces an ORE index for range and ordering queries.
+	OrderAndRange QueryType = "ore"
+
+	// JSONSelector produces an ste_vec selector index for JSON path queries.
+	JSONSelector QueryType = "ste_vec_selector"
+
+	// JSONContains produces an ste_vec term index for JSON containment queries.
+	JSONContains QueryType = "ste_vec_term"
+)
+
+// ---------------------------------------------------------------------------
+// CastAs and schema config types (exported for schema building and FFI JSON)
+// ---------------------------------------------------------------------------
+
+// CastAs represents the target data type for column casting in the encryption config.
 type CastAs string
 
 const (
@@ -37,89 +95,26 @@ const (
 	CastAsJson    CastAs = "json"
 )
 
-// ErrorCode represents a structured error code returned by the FFI layer
-type ErrorCode string
-
-const (
-	ErrInvariantViolation       ErrorCode = "INVARIANT_VIOLATION"
-	ErrUnknownQueryOp           ErrorCode = "UNKNOWN_QUERY_OP"
-	ErrUnknownColumn            ErrorCode = "UNKNOWN_COLUMN"
-	ErrMissingIndex             ErrorCode = "MISSING_INDEX"
-	ErrInvalidQueryInput        ErrorCode = "INVALID_QUERY_INPUT"
-	ErrInvalidJsonPath          ErrorCode = "INVALID_JSON_PATH"
-	ErrSteVecRequiresJsonCastAs ErrorCode = "STE_VEC_REQUIRES_JSON_CAST_AS"
-	ErrUnknown                  ErrorCode = "UNKNOWN"
-)
-
-// EncryptionError represents a structured error from the encryption FFI layer.
-type EncryptionError struct {
-	Code    ErrorCode
-	Message string
-}
-
-// Error implements the error interface.
-func (e *EncryptionError) Error() string {
-	return e.Message
-}
-
-// inferErrorCode infers an error code from the error message returned by the FFI layer.
-func inferErrorCode(msg string) ErrorCode {
-	switch {
-	case strings.Contains(msg, "invariant violation"):
-		return ErrInvariantViolation
-	case strings.Contains(msg, "Unknown query operation"):
-		return ErrUnknownQueryOp
-	case strings.Contains(msg, "not found in Encrypt config"):
-		return ErrUnknownColumn
-	case strings.Contains(msg, "does not have a"):
-		return ErrMissingIndex
-	case strings.Contains(msg, "Invalid query input"):
-		return ErrInvalidQueryInput
-	case strings.Contains(msg, "Invalid JSON path"):
-		return ErrInvalidJsonPath
-	case strings.Contains(msg, "ste_vec index requires cast_as"):
-		return ErrSteVecRequiresJsonCastAs
-	default:
-		return ErrUnknown
-	}
-}
-
-// newEncryptionError creates a new EncryptionError with an inferred error code.
-func newEncryptionError(msg string) *EncryptionError {
-	return &EncryptionError{
-		Code:    inferErrorCode(msg),
-		Message: msg,
-	}
-}
-
-// Identifier represents a table and column identifier
+// Identifier represents a table and column identifier in the EQL wire format.
 type Identifier struct {
 	Table  string `json:"t"`
 	Column string `json:"c"`
 }
 
-// NewIdentifier creates a new identifier
-func NewIdentifier(table, column string) Identifier {
-	return Identifier{
-		Table:  table,
-		Column: column,
-	}
-}
-
-// OreIndexOpts represents options for ORE index
+// OreIndexOpts represents options for an ORE (order-revealing encryption) index.
 type OreIndexOpts struct{}
 
-// UniqueIndexOpts represents options for unique index
+// UniqueIndexOpts represents options for a unique (HMAC) index.
 type UniqueIndexOpts struct {
 	TokenFilters []TokenFilter `json:"token_filters,omitempty"`
 }
 
-// TokenFilter represents a token filter configuration
+// TokenFilter represents a token filter configuration (e.g., downcase).
 type TokenFilter struct {
 	Kind string `json:"kind"`
 }
 
-// MatchIndexOpts represents options for match index
+// MatchIndexOpts represents options for a match (bloom filter) index.
 type MatchIndexOpts struct {
 	Tokenizer       *Tokenizer    `json:"tokenizer,omitempty"`
 	TokenFilters    []TokenFilter `json:"token_filters,omitempty"`
@@ -128,20 +123,20 @@ type MatchIndexOpts struct {
 	IncludeOriginal *bool         `json:"include_original,omitempty"`
 }
 
-// Tokenizer represents tokenizer configuration
+// Tokenizer represents tokenizer configuration for a match index.
 type Tokenizer struct {
 	Kind        string `json:"kind"`
 	TokenLength *int   `json:"token_length,omitempty"`
 }
 
-// SteVecIndexOpts represents options for SteVec index
+// SteVecIndexOpts represents options for an SteVec (structured encryption vector) index.
 type SteVecIndexOpts struct {
 	Prefix         string        `json:"prefix"`
 	TermFilters    []TokenFilter `json:"term_filters,omitempty"`
 	ArrayIndexMode *string       `json:"array_index_mode,omitempty"`
 }
 
-// Indexes represents the indexes configuration for a column
+// Indexes represents the index configuration for an encrypted column.
 type Indexes struct {
 	OreIndex    *OreIndexOpts    `json:"ore,omitempty"`
 	UniqueIndex *UniqueIndexOpts `json:"unique,omitempty"`
@@ -149,164 +144,215 @@ type Indexes struct {
 	SteVecIndex *SteVecIndexOpts `json:"ste_vec,omitempty"`
 }
 
-// Column represents a column configuration
+// Column represents the encryption configuration for a single column.
 type Column struct {
 	CastAs  *CastAs  `json:"cast_as,omitempty"`
 	Indexes *Indexes `json:"indexes,omitempty"`
 }
 
-// Table represents a table configuration with its columns
+// Table represents a table configuration with its columns.
 type Table map[string]Column
 
-// Tables represents all tables configuration
+// Tables represents all table configurations.
 type Tables map[string]Table
 
-// EncryptConfig represents the encryption configuration
+// EncryptConfig represents the complete encryption configuration sent to the FFI.
 type EncryptConfig struct {
 	Version uint32 `json:"v"`
 	Tables  Tables `json:"tables"`
 }
 
-// KeysetConfig represents keyset configuration for the client
-type KeysetConfig struct {
-	Name *string `json:"name,omitempty"`
-	ID   *string `json:"id,omitempty"`
-}
-
-// ClientOpts represents client configuration options
-type ClientOpts struct {
-	WorkspaceCrn *string       `json:"workspaceCrn,omitempty"`
-	AccessKey    *string       `json:"accessKey,omitempty"`
-	ClientID     *string       `json:"clientId,omitempty"`
-	ClientKey    *string       `json:"clientKey,omitempty"`
-	Keyset       *KeysetConfig `json:"keyset,omitempty"`
-}
-
-// NewClientOptions represents options for creating a new client
-type NewClientOptions struct {
-	EncryptConfig EncryptConfig `json:"encryptConfig"`
-	ClientOpts    *ClientOpts   `json:"clientOpts,omitempty"`
-}
-
-// LockContext represents a lock context for encryption/decryption
+// LockContext represents identity claims for identity-aware encryption.
 type LockContext struct {
 	IdentityClaim []string `json:"identityClaim"`
 }
 
-// EncryptOptions represents options for encryption
-type EncryptOptions struct {
-	Plaintext         interface{}  `json:"plaintext"`
-	Column            string       `json:"column"`
-	Table             string       `json:"table"`
-	LockContext       *LockContext `json:"lockContext,omitempty"`
-	ServiceToken      *string      `json:"serviceToken,omitempty"`
-	UnverifiedContext interface{}  `json:"unverifiedContext,omitempty"`
-}
-
-// PlaintextPayload represents a single plaintext item for bulk encryption
-type PlaintextPayload struct {
-	Plaintext   interface{}  `json:"plaintext"`
-	Column      string       `json:"column"`
-	Table       string       `json:"table"`
-	LockContext *LockContext `json:"lockContext,omitempty"`
-}
-
-// EncryptBulkOptions represents options for bulk encryption
-type EncryptBulkOptions struct {
-	Plaintexts        []PlaintextPayload `json:"plaintexts"`
-	ServiceToken      *string            `json:"serviceToken,omitempty"`
-	UnverifiedContext interface{}        `json:"unverifiedContext,omitempty"`
-}
-
-// DecryptOptions represents options for decryption
-type DecryptOptions struct {
-	Ciphertext        *Encrypted   `json:"ciphertext"`
-	LockContext       *LockContext `json:"lockContext,omitempty"`
-	ServiceToken      *string      `json:"serviceToken,omitempty"`
-	UnverifiedContext interface{}  `json:"unverifiedContext,omitempty"`
-}
-
-// BulkDecryptPayload represents a single ciphertext item for bulk decryption
-type BulkDecryptPayload struct {
-	Ciphertext  *Encrypted   `json:"ciphertext"`
-	LockContext *LockContext `json:"lockContext,omitempty"`
-}
-
-// DecryptBulkOptions represents options for bulk decryption
-type DecryptBulkOptions struct {
-	Ciphertexts       []BulkDecryptPayload `json:"ciphertexts"`
-	ServiceToken      *string              `json:"serviceToken,omitempty"`
-	UnverifiedContext interface{}          `json:"unverifiedContext,omitempty"`
-}
-
-// Encrypted represents an encrypted value with its metadata
+// Encrypted represents an encrypted value with its metadata and indexes.
+// The JSON tags match the EQL wire format and must not be changed.
 type Encrypted struct {
-	Identifier  Identifier  `json:"i"`
-	Version     uint16      `json:"v"`
-	Ciphertext  *string     `json:"c,omitempty"`
-	OreIndex    *[]string   `json:"ob,omitempty"`
-	MatchIndex  *[]uint16   `json:"bf,omitempty"`
-	UniqueIndex *string     `json:"hm,omitempty"`
-	SteVecIndex interface{} `json:"sv,omitempty"`
+	Identifier  Identifier `json:"i"`
+	Version     uint16     `json:"v"`
+	Ciphertext  *string    `json:"c,omitempty"`
+	OreIndex    *[]string  `json:"ob,omitempty"`
+	MatchIndex  *[]uint16  `json:"bf,omitempty"`
+	UniqueIndex *string    `json:"hm,omitempty"`
+	SteVecIndex any        `json:"sv,omitempty"`
 }
 
-// DecryptResult represents the result of a fallible decryption operation
+// PlaintextItem is a single value for bulk encryption.
+type PlaintextItem struct {
+	Column      ColumnRef
+	Plaintext   any
+	LockContext *LockContext // optional per-item override
+}
+
+// QueryItem is a single query for bulk query encryption.
+type QueryItem struct {
+	Column      ColumnRef
+	QueryType   QueryType
+	Plaintext   any
+	LockContext *LockContext // optional per-item override
+}
+
+// DecryptResult represents the result of a single item in a fallible bulk
+// decryption. Exactly one of Data or Err is populated.
 type DecryptResult struct {
-	Data  interface{} `json:"data,omitempty"`
-	Error *string     `json:"error,omitempty"`
+	Data any
+	Err  error
 }
 
-// QueryOp represents the type of query operation for encrypted search
-type QueryOp string
+// ---------------------------------------------------------------------------
+// Client options (functional options for NewClient)
+// ---------------------------------------------------------------------------
 
-const (
-	QueryOpDefault        QueryOp = "default"
-	QueryOpSteVecSelector QueryOp = "ste_vec_selector"
-	QueryOpSteVecTerm     QueryOp = "ste_vec_term"
-)
-
-// IndexType represents the type of index to use for encrypted search
-type IndexType string
-
-const (
-	IndexTypeOre    IndexType = "ore"
-	IndexTypeUnique IndexType = "unique"
-	IndexTypeMatch  IndexType = "match"
-	IndexTypeSteVec IndexType = "ste_vec"
-)
-
-// EncryptQueryOptions represents options for encrypting a query value
-type EncryptQueryOptions struct {
-	Plaintext         interface{}  `json:"plaintext"`
-	Column            string       `json:"column"`
-	Table             string       `json:"table"`
-	IndexType         IndexType    `json:"indexType"`
-	QueryOp           QueryOp      `json:"queryOp,omitempty"`
-	LockContext       *LockContext `json:"lockContext,omitempty"`
-	ServiceToken      *string      `json:"serviceToken,omitempty"`
-	UnverifiedContext interface{}  `json:"unverifiedContext,omitempty"`
+type clientConfig struct {
+	schemas      []*TableDef
+	workspaceCRN string
+	accessKey    string
+	clientID     string
+	clientKey    string
+	keysetName   string
+	keysetID     string
 }
 
-// QueryPayload represents a single query item for bulk query encryption
-type QueryPayload struct {
-	Plaintext   interface{}  `json:"plaintext"`
-	Column      string       `json:"column"`
-	Table       string       `json:"table"`
-	IndexType   IndexType    `json:"indexType"`
-	QueryOp     QueryOp      `json:"queryOp,omitempty"`
-	LockContext *LockContext `json:"lockContext,omitempty"`
+// ClientOption configures the Client during construction.
+type ClientOption func(*clientConfig)
+
+// WithSchemas registers one or more table schemas with the client.
+// The schemas define which tables and columns can be encrypted.
+func WithSchemas(schemas ...*TableDef) ClientOption {
+	return func(c *clientConfig) {
+		c.schemas = append(c.schemas, schemas...)
+	}
 }
 
-// EncryptQueryBulkOptions represents options for bulk query encryption
-type EncryptQueryBulkOptions struct {
-	Queries           []QueryPayload `json:"queries"`
-	ServiceToken      *string        `json:"serviceToken,omitempty"`
-	UnverifiedContext interface{}    `json:"unverifiedContext,omitempty"`
+// WithCredentials sets explicit credentials for the client.
+// If not provided, the client falls back to environment variables.
+func WithCredentials(workspaceCRN, accessKey, clientID, clientKey string) ClientOption {
+	return func(c *clientConfig) {
+		c.workspaceCRN = workspaceCRN
+		c.accessKey = accessKey
+		c.clientID = clientID
+		c.clientKey = clientKey
+	}
 }
 
-// NewClient creates a new protect FFI client
-func NewClient(options NewClientOptions) (*Client, error) {
-	optionsJSON, err := json.Marshal(options)
+// WithKeyset selects a named keyset for multi-tenant key isolation.
+func WithKeyset(name string) ClientOption {
+	return func(c *clientConfig) {
+		c.keysetName = name
+	}
+}
+
+// WithKeysetID selects a keyset by its unique identifier.
+func WithKeysetID(id string) ClientOption {
+	return func(c *clientConfig) {
+		c.keysetID = id
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Operation options (functional options for Encrypt/Decrypt/Query calls)
+// ---------------------------------------------------------------------------
+
+type callOpts struct {
+	lockContext       *LockContext
+	serviceToken      *string
+	unverifiedContext any
+}
+
+// Option configures optional parameters for encrypt, decrypt, and query operations.
+type Option func(*callOpts)
+
+// WithLockContext attaches identity claims for identity-aware encryption.
+func WithLockContext(lc *LockContext) Option {
+	return func(o *callOpts) { o.lockContext = lc }
+}
+
+// WithServiceToken sets an explicit service token for the operation.
+func WithServiceToken(token string) Option {
+	return func(o *callOpts) { o.serviceToken = &token }
+}
+
+// WithAuditContext attaches unverified context for audit logging.
+func WithAuditContext(ctx any) Option {
+	return func(o *callOpts) { o.unverifiedContext = ctx }
+}
+
+func buildCallOpts(opts []Option) callOpts {
+	var co callOpts
+	for _, opt := range opts {
+		opt(&co)
+	}
+	return co
+}
+
+// ---------------------------------------------------------------------------
+// NewClient
+// ---------------------------------------------------------------------------
+
+// NewClient creates a new protect client configured with the given options.
+// The ctx parameter is checked for cancellation before the FFI call.
+func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
+	cfg := &clientConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	encryptConfig := buildEncryptConfigFromSchemas(cfg.schemas)
+
+	type ffiKeyset struct {
+		Name *string `json:"name,omitempty"`
+		ID   *string `json:"id,omitempty"`
+	}
+	type ffiClientOpts struct {
+		WorkspaceCrn *string    `json:"workspaceCrn,omitempty"`
+		AccessKey    *string    `json:"accessKey,omitempty"`
+		ClientID     *string    `json:"clientId,omitempty"`
+		ClientKey    *string    `json:"clientKey,omitempty"`
+		Keyset       *ffiKeyset `json:"keyset,omitempty"`
+	}
+	type ffiNewClientOptions struct {
+		EncryptConfig EncryptConfig  `json:"encryptConfig"`
+		ClientOpts    *ffiClientOpts `json:"clientOpts,omitempty"`
+	}
+
+	ffiOpts := ffiNewClientOptions{
+		EncryptConfig: encryptConfig,
+	}
+
+	if cfg.workspaceCRN != "" || cfg.accessKey != "" || cfg.clientID != "" || cfg.clientKey != "" || cfg.keysetName != "" || cfg.keysetID != "" {
+		co := &ffiClientOpts{}
+		if cfg.workspaceCRN != "" {
+			co.WorkspaceCrn = &cfg.workspaceCRN
+		}
+		if cfg.accessKey != "" {
+			co.AccessKey = &cfg.accessKey
+		}
+		if cfg.clientID != "" {
+			co.ClientID = &cfg.clientID
+		}
+		if cfg.clientKey != "" {
+			co.ClientKey = &cfg.clientKey
+		}
+		if cfg.keysetName != "" || cfg.keysetID != "" {
+			ks := &ffiKeyset{}
+			if cfg.keysetName != "" {
+				ks.Name = &cfg.keysetName
+			}
+			if cfg.keysetID != "" {
+				ks.ID = &cfg.keysetID
+			}
+			co.Keyset = ks
+		}
+		ffiOpts.ClientOpts = co
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -315,31 +361,64 @@ func NewClient(options NewClientOptions) (*Client, error) {
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
 	result := C.protect_new_client(cOptionsJSON)
-
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newEncryptionError(errorStr)
+		return nil, newError("NewClient", errorStr)
 	}
 
 	return &Client{ptr: unsafe.Pointer(result.data)}, nil
 }
 
-// Free releases the resources held by the client
-func (c *Client) Free() {
-	if c.ptr != nil {
-		C.protect_free_client((*C.struct_Client)(c.ptr))
-		c.ptr = nil
+func buildEncryptConfigFromSchemas(schemas []*TableDef) EncryptConfig {
+	tbls := make(Tables, len(schemas))
+	for _, td := range schemas {
+		tbl := make(Table, len(td.columns))
+		for colName, col := range td.columns {
+			tbl[colName] = col
+		}
+		tbls[td.name] = tbl
+	}
+	return EncryptConfig{
+		Version: 1,
+		Tables:  tbls,
 	}
 }
 
-// Encrypt encrypts a single plaintext value
-func (c *Client) Encrypt(options EncryptOptions) (*Encrypted, error) {
+// ---------------------------------------------------------------------------
+// Encrypt
+// ---------------------------------------------------------------------------
+
+// Encrypt encrypts a single plaintext value for the given column.
+func (c *Client) Encrypt(ctx context.Context, col ColumnRef, plaintext any, opts ...Option) (*Encrypted, error) {
 	if c.ptr == nil {
-		return nil, newEncryptionError("client has been freed")
+		return nil, &Error{Op: "Encrypt", Err: ErrClientClosed, Message: "protect: client is closed"}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
-	optionsJSON, err := json.Marshal(options)
+	co := buildCallOpts(opts)
+
+	type ffiEncryptOptions struct {
+		Plaintext         any          `json:"plaintext"`
+		Column            string       `json:"column"`
+		Table             string       `json:"table"`
+		LockContext       *LockContext `json:"lockContext,omitempty"`
+		ServiceToken      *string      `json:"serviceToken,omitempty"`
+		UnverifiedContext any          `json:"unverifiedContext,omitempty"`
+	}
+
+	ffiOpts := ffiEncryptOptions{
+		Plaintext:         plaintext,
+		Column:            col.column,
+		Table:             col.table,
+		LockContext:       co.lockContext,
+		ServiceToken:      co.serviceToken,
+		UnverifiedContext: co.unverifiedContext,
+	}
+
+	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -348,11 +427,10 @@ func (c *Client) Encrypt(options EncryptOptions) (*Encrypted, error) {
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
 	result := C.protect_encrypt((*C.struct_Client)(c.ptr), cOptionsJSON)
-
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newEncryptionError(errorStr)
+		return nil, newError("Encrypt", errorStr)
 	}
 
 	encryptedJSON := C.GoString(result.data)
@@ -366,112 +444,36 @@ func (c *Client) Encrypt(options EncryptOptions) (*Encrypted, error) {
 	return &encrypted, nil
 }
 
-// EncryptBulk encrypts multiple plaintext values
-func (c *Client) EncryptBulk(options EncryptBulkOptions) ([]Encrypted, error) {
+// ---------------------------------------------------------------------------
+// Decrypt
+// ---------------------------------------------------------------------------
+
+// Decrypt decrypts a single encrypted value and returns the plaintext.
+func (c *Client) Decrypt(ctx context.Context, encrypted *Encrypted, opts ...Option) (any, error) {
 	if c.ptr == nil {
-		return nil, newEncryptionError("client has been freed")
+		return nil, &Error{Op: "Decrypt", Err: ErrClientClosed, Message: "protect: client is closed"}
 	}
-
-	optionsJSON, err := json.Marshal(options)
-	if err != nil {
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
-	cOptionsJSON := C.CString(string(optionsJSON))
-	defer C.free(unsafe.Pointer(cOptionsJSON))
+	co := buildCallOpts(opts)
 
-	result := C.protect_encrypt_bulk((*C.struct_Client)(c.ptr), cOptionsJSON)
-
-	if !result.success {
-		errorStr := C.GoString(result.error)
-		C.protect_free_string(result.error)
-		return nil, newEncryptionError(errorStr)
+	type ffiDecryptOptions struct {
+		Ciphertext        *Encrypted   `json:"ciphertext"`
+		LockContext       *LockContext `json:"lockContext,omitempty"`
+		ServiceToken      *string      `json:"serviceToken,omitempty"`
+		UnverifiedContext any          `json:"unverifiedContext,omitempty"`
 	}
 
-	encryptedJSON := C.GoString(result.data)
-	C.protect_free_string(result.data)
-
-	var encrypted []Encrypted
-	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
-		return nil, err
+	ffiOpts := ffiDecryptOptions{
+		Ciphertext:        encrypted,
+		LockContext:       co.lockContext,
+		ServiceToken:      co.serviceToken,
+		UnverifiedContext: co.unverifiedContext,
 	}
 
-	return encrypted, nil
-}
-
-// EncryptQuery encrypts a value for searching against encrypted columns
-func (c *Client) EncryptQuery(options EncryptQueryOptions) (*Encrypted, error) {
-	if c.ptr == nil {
-		return nil, newEncryptionError("client has been freed")
-	}
-
-	optionsJSON, err := json.Marshal(options)
-	if err != nil {
-		return nil, err
-	}
-
-	cOptionsJSON := C.CString(string(optionsJSON))
-	defer C.free(unsafe.Pointer(cOptionsJSON))
-
-	result := C.protect_encrypt_query((*C.struct_Client)(c.ptr), cOptionsJSON)
-
-	if !result.success {
-		errorStr := C.GoString(result.error)
-		C.protect_free_string(result.error)
-		return nil, newEncryptionError(errorStr)
-	}
-
-	encryptedJSON := C.GoString(result.data)
-	C.protect_free_string(result.data)
-
-	var encrypted Encrypted
-	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
-		return nil, err
-	}
-
-	return &encrypted, nil
-}
-
-// EncryptQueryBulk encrypts multiple values for searching against encrypted columns
-func (c *Client) EncryptQueryBulk(options EncryptQueryBulkOptions) ([]Encrypted, error) {
-	if c.ptr == nil {
-		return nil, newEncryptionError("client has been freed")
-	}
-
-	optionsJSON, err := json.Marshal(options)
-	if err != nil {
-		return nil, err
-	}
-
-	cOptionsJSON := C.CString(string(optionsJSON))
-	defer C.free(unsafe.Pointer(cOptionsJSON))
-
-	result := C.protect_encrypt_query_bulk((*C.struct_Client)(c.ptr), cOptionsJSON)
-
-	if !result.success {
-		errorStr := C.GoString(result.error)
-		C.protect_free_string(result.error)
-		return nil, newEncryptionError(errorStr)
-	}
-
-	encryptedJSON := C.GoString(result.data)
-	C.protect_free_string(result.data)
-
-	var encrypted []Encrypted
-	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
-		return nil, err
-	}
-
-	return encrypted, nil
-}
-
-// Decrypt decrypts a single ciphertext value
-func (c *Client) Decrypt(options DecryptOptions) (interface{}, error) {
-	if c.ptr == nil {
-		return nil, newEncryptionError("client has been freed")
-	}
-
-	optionsJSON, err := json.Marshal(options)
+	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -480,17 +482,16 @@ func (c *Client) Decrypt(options DecryptOptions) (interface{}, error) {
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
 	result := C.protect_decrypt((*C.struct_Client)(c.ptr), cOptionsJSON)
-
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newEncryptionError(errorStr)
+		return nil, newError("Decrypt", errorStr)
 	}
 
 	plaintextJSON := C.GoString(result.data)
 	C.protect_free_string(result.data)
 
-	var plaintext interface{}
+	var plaintext any
 	if err := json.Unmarshal([]byte(plaintextJSON), &plaintext); err != nil {
 		return nil, err
 	}
@@ -498,13 +499,120 @@ func (c *Client) Decrypt(options DecryptOptions) (interface{}, error) {
 	return plaintext, nil
 }
 
-// DecryptBulk decrypts multiple ciphertext values
-func (c *Client) DecryptBulk(options DecryptBulkOptions) ([]interface{}, error) {
+// ---------------------------------------------------------------------------
+// EncryptBulk
+// ---------------------------------------------------------------------------
+
+// EncryptBulk encrypts multiple plaintext values in a single operation.
+func (c *Client) EncryptBulk(ctx context.Context, items []PlaintextItem, opts ...Option) ([]Encrypted, error) {
 	if c.ptr == nil {
-		return nil, newEncryptionError("client has been freed")
+		return nil, &Error{Op: "EncryptBulk", Err: ErrClientClosed, Message: "protect: client is closed"}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
-	optionsJSON, err := json.Marshal(options)
+	co := buildCallOpts(opts)
+
+	type ffiPlaintextPayload struct {
+		Plaintext   any          `json:"plaintext"`
+		Column      string       `json:"column"`
+		Table       string       `json:"table"`
+		LockContext *LockContext `json:"lockContext,omitempty"`
+	}
+	type ffiBulkOptions struct {
+		Plaintexts        []ffiPlaintextPayload `json:"plaintexts"`
+		ServiceToken      *string               `json:"serviceToken,omitempty"`
+		UnverifiedContext any                   `json:"unverifiedContext,omitempty"`
+	}
+
+	payloads := make([]ffiPlaintextPayload, len(items))
+	for i, item := range items {
+		lc := item.LockContext
+		if lc == nil {
+			lc = co.lockContext
+		}
+		payloads[i] = ffiPlaintextPayload{
+			Plaintext:   item.Plaintext,
+			Column:      item.Column.column,
+			Table:       item.Column.table,
+			LockContext: lc,
+		}
+	}
+
+	ffiOpts := ffiBulkOptions{
+		Plaintexts:        payloads,
+		ServiceToken:      co.serviceToken,
+		UnverifiedContext: co.unverifiedContext,
+	}
+
+	optionsJSON, err := json.Marshal(ffiOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	cOptionsJSON := C.CString(string(optionsJSON))
+	defer C.free(unsafe.Pointer(cOptionsJSON))
+
+	result := C.protect_encrypt_bulk((*C.struct_Client)(c.ptr), cOptionsJSON)
+	if !result.success {
+		errorStr := C.GoString(result.error)
+		C.protect_free_string(result.error)
+		return nil, newError("EncryptBulk", errorStr)
+	}
+
+	encryptedJSON := C.GoString(result.data)
+	C.protect_free_string(result.data)
+
+	var encrypted []Encrypted
+	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
+		return nil, err
+	}
+
+	return encrypted, nil
+}
+
+// ---------------------------------------------------------------------------
+// DecryptBulk
+// ---------------------------------------------------------------------------
+
+// DecryptBulk decrypts multiple encrypted values in a single operation.
+// Use WithLockContext to apply a shared lock context to all items.
+func (c *Client) DecryptBulk(ctx context.Context, items []*Encrypted, opts ...Option) ([]any, error) {
+	if c.ptr == nil {
+		return nil, &Error{Op: "DecryptBulk", Err: ErrClientClosed, Message: "protect: client is closed"}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	co := buildCallOpts(opts)
+
+	type ffiBulkDecryptPayload struct {
+		Ciphertext  *Encrypted   `json:"ciphertext"`
+		LockContext *LockContext `json:"lockContext,omitempty"`
+	}
+	type ffiBulkDecryptOptions struct {
+		Ciphertexts       []ffiBulkDecryptPayload `json:"ciphertexts"`
+		ServiceToken      *string                 `json:"serviceToken,omitempty"`
+		UnverifiedContext any                     `json:"unverifiedContext,omitempty"`
+	}
+
+	payloads := make([]ffiBulkDecryptPayload, len(items))
+	for i, item := range items {
+		payloads[i] = ffiBulkDecryptPayload{
+			Ciphertext:  item,
+			LockContext: co.lockContext,
+		}
+	}
+
+	ffiOpts := ffiBulkDecryptOptions{
+		Ciphertexts:       payloads,
+		ServiceToken:      co.serviceToken,
+		UnverifiedContext: co.unverifiedContext,
+	}
+
+	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -513,17 +621,16 @@ func (c *Client) DecryptBulk(options DecryptBulkOptions) ([]interface{}, error) 
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
 	result := C.protect_decrypt_bulk((*C.struct_Client)(c.ptr), cOptionsJSON)
-
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newEncryptionError(errorStr)
+		return nil, newError("DecryptBulk", errorStr)
 	}
 
 	plaintextJSON := C.GoString(result.data)
 	C.protect_free_string(result.data)
 
-	var plaintexts []interface{}
+	var plaintexts []any
 	if err := json.Unmarshal([]byte(plaintextJSON), &plaintexts); err != nil {
 		return nil, err
 	}
@@ -531,13 +638,47 @@ func (c *Client) DecryptBulk(options DecryptBulkOptions) ([]interface{}, error) 
 	return plaintexts, nil
 }
 
-// DecryptBulkFallible decrypts multiple ciphertext values with individual error handling
-func (c *Client) DecryptBulkFallible(options DecryptBulkOptions) ([]DecryptResult, error) {
+// ---------------------------------------------------------------------------
+// DecryptBulkFallible
+// ---------------------------------------------------------------------------
+
+// DecryptBulkFallible decrypts multiple encrypted values, returning per-item
+// results where each item independently succeeds or fails.
+func (c *Client) DecryptBulkFallible(ctx context.Context, items []*Encrypted, opts ...Option) ([]DecryptResult, error) {
 	if c.ptr == nil {
-		return nil, newEncryptionError("client has been freed")
+		return nil, &Error{Op: "DecryptBulkFallible", Err: ErrClientClosed, Message: "protect: client is closed"}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
-	optionsJSON, err := json.Marshal(options)
+	co := buildCallOpts(opts)
+
+	type ffiBulkDecryptPayload struct {
+		Ciphertext  *Encrypted   `json:"ciphertext"`
+		LockContext *LockContext `json:"lockContext,omitempty"`
+	}
+	type ffiBulkDecryptOptions struct {
+		Ciphertexts       []ffiBulkDecryptPayload `json:"ciphertexts"`
+		ServiceToken      *string                 `json:"serviceToken,omitempty"`
+		UnverifiedContext any                     `json:"unverifiedContext,omitempty"`
+	}
+
+	payloads := make([]ffiBulkDecryptPayload, len(items))
+	for i, item := range items {
+		payloads[i] = ffiBulkDecryptPayload{
+			Ciphertext:  item,
+			LockContext: co.lockContext,
+		}
+	}
+
+	ffiOpts := ffiBulkDecryptOptions{
+		Ciphertexts:       payloads,
+		ServiceToken:      co.serviceToken,
+		UnverifiedContext: co.unverifiedContext,
+	}
+
+	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -546,27 +687,187 @@ func (c *Client) DecryptBulkFallible(options DecryptBulkOptions) ([]DecryptResul
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
 	result := C.protect_decrypt_bulk_fallible((*C.struct_Client)(c.ptr), cOptionsJSON)
-
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newEncryptionError(errorStr)
+		return nil, newError("DecryptBulkFallible", errorStr)
 	}
 
 	resultsJSON := C.GoString(result.data)
 	C.protect_free_string(result.data)
 
-	var results []DecryptResult
-	if err := json.Unmarshal([]byte(resultsJSON), &results); err != nil {
+	type ffiDecryptResult struct {
+		Data  any     `json:"data,omitempty"`
+		Error *string `json:"error,omitempty"`
+	}
+
+	var ffiResults []ffiDecryptResult
+	if err := json.Unmarshal([]byte(resultsJSON), &ffiResults); err != nil {
 		return nil, err
+	}
+
+	results := make([]DecryptResult, len(ffiResults))
+	for i, r := range ffiResults {
+		if r.Error != nil {
+			results[i] = DecryptResult{Err: newError("DecryptBulkFallible", *r.Error)}
+		} else {
+			results[i] = DecryptResult{Data: r.Data}
+		}
 	}
 
 	return results, nil
 }
 
-// IsEncrypted checks if a value is a valid encrypted payload.
+// ---------------------------------------------------------------------------
+// EncryptQuery
+// ---------------------------------------------------------------------------
+
+// EncryptQuery encrypts a value for searching against an encrypted column.
+func (c *Client) EncryptQuery(ctx context.Context, col ColumnRef, queryType QueryType, plaintext any, opts ...Option) (*Encrypted, error) {
+	if c.ptr == nil {
+		return nil, &Error{Op: "EncryptQuery", Err: ErrClientClosed, Message: "protect: client is closed"}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	co := buildCallOpts(opts)
+
+	indexType, queryOp := resolveQueryType(queryType)
+
+	type ffiEncryptQueryOptions struct {
+		Plaintext         any          `json:"plaintext"`
+		Column            string       `json:"column"`
+		Table             string       `json:"table"`
+		IndexType         string       `json:"indexType"`
+		QueryOp           string       `json:"queryOp,omitempty"`
+		LockContext       *LockContext `json:"lockContext,omitempty"`
+		ServiceToken      *string      `json:"serviceToken,omitempty"`
+		UnverifiedContext any          `json:"unverifiedContext,omitempty"`
+	}
+
+	ffiOpts := ffiEncryptQueryOptions{
+		Plaintext:         plaintext,
+		Column:            col.column,
+		Table:             col.table,
+		IndexType:         indexType,
+		QueryOp:           queryOp,
+		LockContext:       co.lockContext,
+		ServiceToken:      co.serviceToken,
+		UnverifiedContext: co.unverifiedContext,
+	}
+
+	optionsJSON, err := json.Marshal(ffiOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	cOptionsJSON := C.CString(string(optionsJSON))
+	defer C.free(unsafe.Pointer(cOptionsJSON))
+
+	result := C.protect_encrypt_query((*C.struct_Client)(c.ptr), cOptionsJSON)
+	if !result.success {
+		errorStr := C.GoString(result.error)
+		C.protect_free_string(result.error)
+		return nil, newError("EncryptQuery", errorStr)
+	}
+
+	encryptedJSON := C.GoString(result.data)
+	C.protect_free_string(result.data)
+
+	var encrypted Encrypted
+	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
+		return nil, err
+	}
+
+	return &encrypted, nil
+}
+
+// ---------------------------------------------------------------------------
+// EncryptQueryBulk
+// ---------------------------------------------------------------------------
+
+// EncryptQueryBulk encrypts multiple query values in a single operation.
+func (c *Client) EncryptQueryBulk(ctx context.Context, queries []QueryItem, opts ...Option) ([]Encrypted, error) {
+	if c.ptr == nil {
+		return nil, &Error{Op: "EncryptQueryBulk", Err: ErrClientClosed, Message: "protect: client is closed"}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	co := buildCallOpts(opts)
+
+	type ffiQueryPayload struct {
+		Plaintext   any          `json:"plaintext"`
+		Column      string       `json:"column"`
+		Table       string       `json:"table"`
+		IndexType   string       `json:"indexType"`
+		QueryOp     string       `json:"queryOp,omitempty"`
+		LockContext *LockContext `json:"lockContext,omitempty"`
+	}
+	type ffiBulkQueryOptions struct {
+		Queries           []ffiQueryPayload `json:"queries"`
+		ServiceToken      *string           `json:"serviceToken,omitempty"`
+		UnverifiedContext any               `json:"unverifiedContext,omitempty"`
+	}
+
+	payloads := make([]ffiQueryPayload, len(queries))
+	for i, q := range queries {
+		indexType, queryOp := resolveQueryType(q.QueryType)
+		lc := q.LockContext
+		if lc == nil {
+			lc = co.lockContext
+		}
+		payloads[i] = ffiQueryPayload{
+			Plaintext:   q.Plaintext,
+			Column:      q.Column.column,
+			Table:       q.Column.table,
+			IndexType:   indexType,
+			QueryOp:     queryOp,
+			LockContext: lc,
+		}
+	}
+
+	ffiOpts := ffiBulkQueryOptions{
+		Queries:           payloads,
+		ServiceToken:      co.serviceToken,
+		UnverifiedContext: co.unverifiedContext,
+	}
+
+	optionsJSON, err := json.Marshal(ffiOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	cOptionsJSON := C.CString(string(optionsJSON))
+	defer C.free(unsafe.Pointer(cOptionsJSON))
+
+	result := C.protect_encrypt_query_bulk((*C.struct_Client)(c.ptr), cOptionsJSON)
+	if !result.success {
+		errorStr := C.GoString(result.error)
+		C.protect_free_string(result.error)
+		return nil, newError("EncryptQueryBulk", errorStr)
+	}
+
+	encryptedJSON := C.GoString(result.data)
+	C.protect_free_string(result.data)
+
+	var encrypted []Encrypted
+	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
+		return nil, err
+	}
+
+	return encrypted, nil
+}
+
+// ---------------------------------------------------------------------------
+// IsEncrypted
+// ---------------------------------------------------------------------------
+
+// IsEncrypted checks whether a value is a valid EQL encrypted payload.
 // This is a standalone function that does not require a Client.
-func IsEncrypted(value interface{}) bool {
+func IsEncrypted(value any) bool {
 	valueJSON, err := json.Marshal(value)
 	if err != nil {
 		return false
@@ -576,4 +877,29 @@ func IsEncrypted(value interface{}) bool {
 	defer C.free(unsafe.Pointer(cValueJSON))
 
 	return bool(C.protect_is_encrypted(cValueJSON))
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// resolveQueryType maps a public QueryType to the FFI's indexType and queryOp
+// string values. For standard index types (unique, match, ore), queryOp is
+// "default". For ste_vec variants, the indexType is "ste_vec" and queryOp
+// carries the specific operation.
+func resolveQueryType(qt QueryType) (indexType string, queryOp string) {
+	switch qt {
+	case Equality:
+		return "unique", "default"
+	case FreeTextSearch:
+		return "match", "default"
+	case OrderAndRange:
+		return "ore", "default"
+	case JSONSelector:
+		return "ste_vec", "ste_vec_selector"
+	case JSONContains:
+		return "ste_vec", "ste_vec_term"
+	default:
+		return string(qt), "default"
+	}
 }

--- a/pkg/protect/protect.go
+++ b/pkg/protect/protect.go
@@ -1,4 +1,5 @@
-// Package protect provides field-level encryption with searchable encryption support.
+// Package protect provides field-level encryption with searchable encryption support,
+// powered by CipherStash ZeroKMS.
 //
 // Define your schema using struct tags or the programmatic builder, then use
 // the Client to encrypt, decrypt, and query encrypted data.
@@ -8,6 +9,18 @@
 //	defer client.Close()
 //
 //	encrypted, err := client.Encrypt(ctx, users.Column("email"), "john@example.com")
+//
+// # Concurrency
+//
+// A Client is safe for concurrent use by multiple goroutines. All exported
+// methods synchronize access to the underlying FFI handle.
+//
+// # Credentials
+//
+// If no explicit credentials are provided via [WithCredentials], the client
+// reads configuration from environment variables (CS_WORKSPACE_CRN,
+// CS_CLIENT_ACCESS_KEY, CS_CLIENT_ID, CS_CLIENT_KEY) or from
+// cipherstash.toml / cipherstash.secret.toml in the working directory.
 package protect
 
 /*
@@ -26,28 +39,50 @@ import "C"
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
 	"unsafe"
 )
+
+// Compile-time interface assertions.
+var _ io.Closer = (*Client)(nil)
 
 // ---------------------------------------------------------------------------
 // Core types
 // ---------------------------------------------------------------------------
 
 // Client is the main entry point for encryption and decryption operations.
-// Create one with NewClient and release resources with Close.
+// Create one with [NewClient] and release resources with [Client.Close].
+//
+// A Client is safe for concurrent use by multiple goroutines.
 type Client struct {
+	mu  sync.RWMutex
 	ptr unsafe.Pointer
 }
 
-// Close releases resources held by the client. Implements io.Closer.
-// It is safe to call Close multiple times.
+// Close releases resources held by the client. Implements [io.Closer].
+// It is safe to call Close multiple times; subsequent calls are no-ops.
 func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.ptr == nil {
 		return nil
 	}
 	C.protect_free_client((*C.struct_Client)(c.ptr))
 	c.ptr = nil
 	return nil
+}
+
+// acquirePtr returns the FFI pointer under a read lock, or an error if the
+// client is closed. The caller must call the returned unlock function when done.
+func (c *Client) acquirePtr(op string) (unsafe.Pointer, func(), error) {
+	c.mu.RLock()
+	if c.ptr == nil {
+		c.mu.RUnlock()
+		return nil, nil, &Error{Op: op, Err: ErrClientClosed, Message: "protect: client is closed"}
+	}
+	return c.ptr, c.mu.RUnlock, nil
 }
 
 // ColumnRef is a reference to an encrypted column within a table schema.
@@ -92,7 +127,12 @@ const (
 	CastAsNumber  CastAs = "number"
 	CastAsString  CastAs = "string"
 	CastAsText    CastAs = "text"
-	CastAsJson    CastAs = "json"
+	CastAsJSON    CastAs = "json"
+
+	// CastAsJson is a deprecated alias for [CastAsJSON].
+	//
+	// Deprecated: Use CastAsJSON instead.
+	CastAsJson = CastAsJSON
 )
 
 // Identifier represents a table and column identifier in the EQL wire format.
@@ -179,26 +219,36 @@ type Encrypted struct {
 	SteVecIndex any        `json:"sv,omitempty"`
 }
 
-// PlaintextItem is a single value for bulk encryption.
+// PlaintextItem is a single value for bulk encryption via [Client.EncryptBulk].
 type PlaintextItem struct {
-	Column      ColumnRef
-	Plaintext   any
-	LockContext *LockContext // optional per-item override
+	// Column identifies the table and column for encryption.
+	Column ColumnRef
+	// Plaintext is the value to encrypt. Must be JSON-serializable.
+	Plaintext any
+	// LockContext optionally overrides the call-level lock context for this item.
+	LockContext *LockContext
 }
 
-// QueryItem is a single query for bulk query encryption.
+// QueryItem is a single query for bulk query encryption via [Client.EncryptQueryBulk].
 type QueryItem struct {
-	Column      ColumnRef
-	QueryType   QueryType
-	Plaintext   any
-	LockContext *LockContext // optional per-item override
+	// Column identifies the table and column to query.
+	Column ColumnRef
+	// QueryType selects the index type for the search.
+	QueryType QueryType
+	// Plaintext is the search term. Must be JSON-serializable.
+	Plaintext any
+	// LockContext optionally overrides the call-level lock context for this item.
+	LockContext *LockContext
 }
 
 // DecryptResult represents the result of a single item in a fallible bulk
-// decryption. Exactly one of Data or Err is populated.
+// decryption via [Client.DecryptBulkFallible]. Exactly one of Data or Err
+// is populated.
 type DecryptResult struct {
+	// Data holds the decrypted plaintext as a JSON-deserialized Go value.
 	Data any
-	Err  error
+	// Err holds the decryption error for this item, if any.
+	Err error
 }
 
 // ---------------------------------------------------------------------------
@@ -349,12 +399,12 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 	}
 
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: NewClient: %w", err)
 	}
 
 	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: NewClient: marshaling options: %w", err)
 	}
 
 	cOptionsJSON := C.CString(string(optionsJSON))
@@ -390,12 +440,20 @@ func buildEncryptConfigFromSchemas(schemas []*TableDef) EncryptConfig {
 // ---------------------------------------------------------------------------
 
 // Encrypt encrypts a single plaintext value for the given column.
+//
+// The plaintext can be any JSON-serializable value. The returned [Encrypted]
+// payload contains the ciphertext and any configured search indexes.
 func (c *Client) Encrypt(ctx context.Context, col ColumnRef, plaintext any, opts ...Option) (*Encrypted, error) {
-	if c.ptr == nil {
-		return nil, &Error{Op: "Encrypt", Err: ErrClientClosed, Message: "protect: client is closed"}
-	}
-	if err := ctx.Err(); err != nil {
+	const op = "Encrypt"
+
+	ptr, unlock, err := c.acquirePtr(op)
+	if err != nil {
 		return nil, err
+	}
+	defer unlock()
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("protect: %s: %w", op, err)
 	}
 
 	co := buildCallOpts(opts)
@@ -420,17 +478,17 @@ func (c *Client) Encrypt(ctx context.Context, col ColumnRef, plaintext any, opts
 
 	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: marshaling options: %w", op, err)
 	}
 
 	cOptionsJSON := C.CString(string(optionsJSON))
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
-	result := C.protect_encrypt((*C.struct_Client)(c.ptr), cOptionsJSON)
+	result := C.protect_encrypt((*C.struct_Client)(ptr), cOptionsJSON)
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newError("Encrypt", errorStr)
+		return nil, newError(op, errorStr)
 	}
 
 	encryptedJSON := C.GoString(result.data)
@@ -438,7 +496,7 @@ func (c *Client) Encrypt(ctx context.Context, col ColumnRef, plaintext any, opts
 
 	var encrypted Encrypted
 	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: unmarshaling result: %w", op, err)
 	}
 
 	return &encrypted, nil
@@ -449,12 +507,20 @@ func (c *Client) Encrypt(ctx context.Context, col ColumnRef, plaintext any, opts
 // ---------------------------------------------------------------------------
 
 // Decrypt decrypts a single encrypted value and returns the plaintext.
+//
+// The returned value is a JSON-deserialized Go value: string, float64, bool,
+// nil, map[string]any, or []any, depending on what was originally encrypted.
 func (c *Client) Decrypt(ctx context.Context, encrypted *Encrypted, opts ...Option) (any, error) {
-	if c.ptr == nil {
-		return nil, &Error{Op: "Decrypt", Err: ErrClientClosed, Message: "protect: client is closed"}
-	}
-	if err := ctx.Err(); err != nil {
+	const op = "Decrypt"
+
+	ptr, unlock, err := c.acquirePtr(op)
+	if err != nil {
 		return nil, err
+	}
+	defer unlock()
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("protect: %s: %w", op, err)
 	}
 
 	co := buildCallOpts(opts)
@@ -475,17 +541,17 @@ func (c *Client) Decrypt(ctx context.Context, encrypted *Encrypted, opts ...Opti
 
 	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: marshaling options: %w", op, err)
 	}
 
 	cOptionsJSON := C.CString(string(optionsJSON))
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
-	result := C.protect_decrypt((*C.struct_Client)(c.ptr), cOptionsJSON)
+	result := C.protect_decrypt((*C.struct_Client)(ptr), cOptionsJSON)
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newError("Decrypt", errorStr)
+		return nil, newError(op, errorStr)
 	}
 
 	plaintextJSON := C.GoString(result.data)
@@ -493,7 +559,7 @@ func (c *Client) Decrypt(ctx context.Context, encrypted *Encrypted, opts ...Opti
 
 	var plaintext any
 	if err := json.Unmarshal([]byte(plaintextJSON), &plaintext); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: unmarshaling result: %w", op, err)
 	}
 
 	return plaintext, nil
@@ -504,12 +570,19 @@ func (c *Client) Decrypt(ctx context.Context, encrypted *Encrypted, opts ...Opti
 // ---------------------------------------------------------------------------
 
 // EncryptBulk encrypts multiple plaintext values in a single operation.
+// This is significantly more efficient than calling [Client.Encrypt] in a loop
+// because it uses a single KMS call for all items.
 func (c *Client) EncryptBulk(ctx context.Context, items []PlaintextItem, opts ...Option) ([]Encrypted, error) {
-	if c.ptr == nil {
-		return nil, &Error{Op: "EncryptBulk", Err: ErrClientClosed, Message: "protect: client is closed"}
-	}
-	if err := ctx.Err(); err != nil {
+	const op = "EncryptBulk"
+
+	ptr, unlock, err := c.acquirePtr(op)
+	if err != nil {
 		return nil, err
+	}
+	defer unlock()
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("protect: %s: %w", op, err)
 	}
 
 	co := buildCallOpts(opts)
@@ -548,17 +621,17 @@ func (c *Client) EncryptBulk(ctx context.Context, items []PlaintextItem, opts ..
 
 	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: marshaling options: %w", op, err)
 	}
 
 	cOptionsJSON := C.CString(string(optionsJSON))
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
-	result := C.protect_encrypt_bulk((*C.struct_Client)(c.ptr), cOptionsJSON)
+	result := C.protect_encrypt_bulk((*C.struct_Client)(ptr), cOptionsJSON)
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newError("EncryptBulk", errorStr)
+		return nil, newError(op, errorStr)
 	}
 
 	encryptedJSON := C.GoString(result.data)
@@ -566,7 +639,7 @@ func (c *Client) EncryptBulk(ctx context.Context, items []PlaintextItem, opts ..
 
 	var encrypted []Encrypted
 	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: unmarshaling result: %w", op, err)
 	}
 
 	return encrypted, nil
@@ -577,13 +650,18 @@ func (c *Client) EncryptBulk(ctx context.Context, items []PlaintextItem, opts ..
 // ---------------------------------------------------------------------------
 
 // DecryptBulk decrypts multiple encrypted values in a single operation.
-// Use WithLockContext to apply a shared lock context to all items.
+// Use [WithLockContext] to apply a shared lock context to all items.
 func (c *Client) DecryptBulk(ctx context.Context, items []*Encrypted, opts ...Option) ([]any, error) {
-	if c.ptr == nil {
-		return nil, &Error{Op: "DecryptBulk", Err: ErrClientClosed, Message: "protect: client is closed"}
-	}
-	if err := ctx.Err(); err != nil {
+	const op = "DecryptBulk"
+
+	ptr, unlock, err := c.acquirePtr(op)
+	if err != nil {
 		return nil, err
+	}
+	defer unlock()
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("protect: %s: %w", op, err)
 	}
 
 	co := buildCallOpts(opts)
@@ -614,17 +692,17 @@ func (c *Client) DecryptBulk(ctx context.Context, items []*Encrypted, opts ...Op
 
 	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: marshaling options: %w", op, err)
 	}
 
 	cOptionsJSON := C.CString(string(optionsJSON))
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
-	result := C.protect_decrypt_bulk((*C.struct_Client)(c.ptr), cOptionsJSON)
+	result := C.protect_decrypt_bulk((*C.struct_Client)(ptr), cOptionsJSON)
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newError("DecryptBulk", errorStr)
+		return nil, newError(op, errorStr)
 	}
 
 	plaintextJSON := C.GoString(result.data)
@@ -632,7 +710,7 @@ func (c *Client) DecryptBulk(ctx context.Context, items []*Encrypted, opts ...Op
 
 	var plaintexts []any
 	if err := json.Unmarshal([]byte(plaintextJSON), &plaintexts); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: unmarshaling result: %w", op, err)
 	}
 
 	return plaintexts, nil
@@ -644,12 +722,20 @@ func (c *Client) DecryptBulk(ctx context.Context, items []*Encrypted, opts ...Op
 
 // DecryptBulkFallible decrypts multiple encrypted values, returning per-item
 // results where each item independently succeeds or fails.
+//
+// Unlike [Client.DecryptBulk], a single item's failure does not cause the
+// entire operation to fail. Check each [DecryptResult.Err] individually.
 func (c *Client) DecryptBulkFallible(ctx context.Context, items []*Encrypted, opts ...Option) ([]DecryptResult, error) {
-	if c.ptr == nil {
-		return nil, &Error{Op: "DecryptBulkFallible", Err: ErrClientClosed, Message: "protect: client is closed"}
-	}
-	if err := ctx.Err(); err != nil {
+	const op = "DecryptBulkFallible"
+
+	ptr, unlock, err := c.acquirePtr(op)
+	if err != nil {
 		return nil, err
+	}
+	defer unlock()
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("protect: %s: %w", op, err)
 	}
 
 	co := buildCallOpts(opts)
@@ -680,17 +766,17 @@ func (c *Client) DecryptBulkFallible(ctx context.Context, items []*Encrypted, op
 
 	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: marshaling options: %w", op, err)
 	}
 
 	cOptionsJSON := C.CString(string(optionsJSON))
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
-	result := C.protect_decrypt_bulk_fallible((*C.struct_Client)(c.ptr), cOptionsJSON)
+	result := C.protect_decrypt_bulk_fallible((*C.struct_Client)(ptr), cOptionsJSON)
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newError("DecryptBulkFallible", errorStr)
+		return nil, newError(op, errorStr)
 	}
 
 	resultsJSON := C.GoString(result.data)
@@ -703,13 +789,13 @@ func (c *Client) DecryptBulkFallible(ctx context.Context, items []*Encrypted, op
 
 	var ffiResults []ffiDecryptResult
 	if err := json.Unmarshal([]byte(resultsJSON), &ffiResults); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: unmarshaling result: %w", op, err)
 	}
 
 	results := make([]DecryptResult, len(ffiResults))
 	for i, r := range ffiResults {
 		if r.Error != nil {
-			results[i] = DecryptResult{Err: newError("DecryptBulkFallible", *r.Error)}
+			results[i] = DecryptResult{Err: newError(op, *r.Error)}
 		} else {
 			results[i] = DecryptResult{Data: r.Data}
 		}
@@ -723,12 +809,22 @@ func (c *Client) DecryptBulkFallible(ctx context.Context, items []*Encrypted, op
 // ---------------------------------------------------------------------------
 
 // EncryptQuery encrypts a value for searching against an encrypted column.
+//
+// The queryType determines which index is used for the search. For example,
+// [Equality] produces an HMAC for exact-match, [FreeTextSearch] produces a
+// bloom filter for full-text search, and [OrderAndRange] produces an ORE
+// ciphertext for range comparisons.
 func (c *Client) EncryptQuery(ctx context.Context, col ColumnRef, queryType QueryType, plaintext any, opts ...Option) (*Encrypted, error) {
-	if c.ptr == nil {
-		return nil, &Error{Op: "EncryptQuery", Err: ErrClientClosed, Message: "protect: client is closed"}
-	}
-	if err := ctx.Err(); err != nil {
+	const op = "EncryptQuery"
+
+	ptr, unlock, err := c.acquirePtr(op)
+	if err != nil {
 		return nil, err
+	}
+	defer unlock()
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("protect: %s: %w", op, err)
 	}
 
 	co := buildCallOpts(opts)
@@ -759,17 +855,17 @@ func (c *Client) EncryptQuery(ctx context.Context, col ColumnRef, queryType Quer
 
 	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: marshaling options: %w", op, err)
 	}
 
 	cOptionsJSON := C.CString(string(optionsJSON))
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
-	result := C.protect_encrypt_query((*C.struct_Client)(c.ptr), cOptionsJSON)
+	result := C.protect_encrypt_query((*C.struct_Client)(ptr), cOptionsJSON)
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newError("EncryptQuery", errorStr)
+		return nil, newError(op, errorStr)
 	}
 
 	encryptedJSON := C.GoString(result.data)
@@ -777,7 +873,7 @@ func (c *Client) EncryptQuery(ctx context.Context, col ColumnRef, queryType Quer
 
 	var encrypted Encrypted
 	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: unmarshaling result: %w", op, err)
 	}
 
 	return &encrypted, nil
@@ -789,11 +885,16 @@ func (c *Client) EncryptQuery(ctx context.Context, col ColumnRef, queryType Quer
 
 // EncryptQueryBulk encrypts multiple query values in a single operation.
 func (c *Client) EncryptQueryBulk(ctx context.Context, queries []QueryItem, opts ...Option) ([]Encrypted, error) {
-	if c.ptr == nil {
-		return nil, &Error{Op: "EncryptQueryBulk", Err: ErrClientClosed, Message: "protect: client is closed"}
-	}
-	if err := ctx.Err(); err != nil {
+	const op = "EncryptQueryBulk"
+
+	ptr, unlock, err := c.acquirePtr(op)
+	if err != nil {
 		return nil, err
+	}
+	defer unlock()
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("protect: %s: %w", op, err)
 	}
 
 	co := buildCallOpts(opts)
@@ -837,17 +938,17 @@ func (c *Client) EncryptQueryBulk(ctx context.Context, queries []QueryItem, opts
 
 	optionsJSON, err := json.Marshal(ffiOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: marshaling options: %w", op, err)
 	}
 
 	cOptionsJSON := C.CString(string(optionsJSON))
 	defer C.free(unsafe.Pointer(cOptionsJSON))
 
-	result := C.protect_encrypt_query_bulk((*C.struct_Client)(c.ptr), cOptionsJSON)
+	result := C.protect_encrypt_query_bulk((*C.struct_Client)(ptr), cOptionsJSON)
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, newError("EncryptQueryBulk", errorStr)
+		return nil, newError(op, errorStr)
 	}
 
 	encryptedJSON := C.GoString(result.data)
@@ -855,7 +956,7 @@ func (c *Client) EncryptQueryBulk(ctx context.Context, queries []QueryItem, opts
 
 	var encrypted []Encrypted
 	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("protect: %s: unmarshaling result: %w", op, err)
 	}
 
 	return encrypted, nil
@@ -866,7 +967,9 @@ func (c *Client) EncryptQueryBulk(ctx context.Context, queries []QueryItem, opts
 // ---------------------------------------------------------------------------
 
 // IsEncrypted checks whether a value is a valid EQL encrypted payload.
-// This is a standalone function that does not require a Client.
+// This is a standalone function that does not require a [Client].
+//
+// Note: this function makes a CGO call to validate the payload structure.
 func IsEncrypted(value any) bool {
 	valueJSON, err := json.Marshal(value)
 	if err != nil {

--- a/pkg/protect/protect.go
+++ b/pkg/protect/protect.go
@@ -15,7 +15,7 @@ package protect
 import "C"
 import (
 	"encoding/json"
-	"errors"
+	"strings"
 	"unsafe"
 )
 
@@ -28,16 +28,69 @@ type Client struct {
 type CastAs string
 
 const (
-	CastAsBigInt   CastAs = "big_int"
-	CastAsBoolean  CastAs = "boolean"
-	CastAsDate     CastAs = "date"
-	CastAsReal     CastAs = "real"
-	CastAsDouble   CastAs = "double"
-	CastAsInt      CastAs = "int"
-	CastAsSmallInt CastAs = "small_int"
-	CastAsText     CastAs = "text"
-	CastAsJsonB    CastAs = "jsonb"
+	CastAsBigInt  CastAs = "bigint"
+	CastAsBoolean CastAs = "boolean"
+	CastAsDate    CastAs = "date"
+	CastAsNumber  CastAs = "number"
+	CastAsString  CastAs = "string"
+	CastAsText    CastAs = "text"
+	CastAsJson    CastAs = "json"
 )
+
+// ErrorCode represents a structured error code returned by the FFI layer
+type ErrorCode string
+
+const (
+	ErrInvariantViolation       ErrorCode = "INVARIANT_VIOLATION"
+	ErrUnknownQueryOp           ErrorCode = "UNKNOWN_QUERY_OP"
+	ErrUnknownColumn            ErrorCode = "UNKNOWN_COLUMN"
+	ErrMissingIndex             ErrorCode = "MISSING_INDEX"
+	ErrInvalidQueryInput        ErrorCode = "INVALID_QUERY_INPUT"
+	ErrInvalidJsonPath          ErrorCode = "INVALID_JSON_PATH"
+	ErrSteVecRequiresJsonCastAs ErrorCode = "STE_VEC_REQUIRES_JSON_CAST_AS"
+	ErrUnknown                  ErrorCode = "UNKNOWN"
+)
+
+// EncryptionError represents a structured error from the encryption FFI layer.
+type EncryptionError struct {
+	Code    ErrorCode
+	Message string
+}
+
+// Error implements the error interface.
+func (e *EncryptionError) Error() string {
+	return e.Message
+}
+
+// inferErrorCode infers an error code from the error message returned by the FFI layer.
+func inferErrorCode(msg string) ErrorCode {
+	switch {
+	case strings.Contains(msg, "invariant violation"):
+		return ErrInvariantViolation
+	case strings.Contains(msg, "Unknown query operation"):
+		return ErrUnknownQueryOp
+	case strings.Contains(msg, "not found in Encrypt config"):
+		return ErrUnknownColumn
+	case strings.Contains(msg, "does not have a"):
+		return ErrMissingIndex
+	case strings.Contains(msg, "Invalid query input"):
+		return ErrInvalidQueryInput
+	case strings.Contains(msg, "Invalid JSON path"):
+		return ErrInvalidJsonPath
+	case strings.Contains(msg, "ste_vec index requires cast_as"):
+		return ErrSteVecRequiresJsonCastAs
+	default:
+		return ErrUnknown
+	}
+}
+
+// newEncryptionError creates a new EncryptionError with an inferred error code.
+func newEncryptionError(msg string) *EncryptionError {
+	return &EncryptionError{
+		Code:    inferErrorCode(msg),
+		Message: msg,
+	}
+}
 
 // Identifier represents a table and column identifier
 type Identifier struct {
@@ -83,7 +136,9 @@ type Tokenizer struct {
 
 // SteVecIndexOpts represents options for SteVec index
 type SteVecIndexOpts struct {
-	Prefix string `json:"prefix"`
+	Prefix         string        `json:"prefix"`
+	TermFilters    []TokenFilter `json:"term_filters,omitempty"`
+	ArrayIndexMode *string       `json:"array_index_mode,omitempty"`
 }
 
 // Indexes represents the indexes configuration for a column
@@ -112,12 +167,19 @@ type EncryptConfig struct {
 	Tables  Tables `json:"tables"`
 }
 
+// KeysetConfig represents keyset configuration for the client
+type KeysetConfig struct {
+	Name *string `json:"name,omitempty"`
+	ID   *string `json:"id,omitempty"`
+}
+
 // ClientOpts represents client configuration options
 type ClientOpts struct {
-	WorkspaceCrn *string `json:"workspaceCrn,omitempty"`
-	AccessKey    *string `json:"accessKey,omitempty"`
-	ClientID     *string `json:"clientId,omitempty"`
-	ClientKey    *string `json:"clientKey,omitempty"`
+	WorkspaceCrn *string       `json:"workspaceCrn,omitempty"`
+	AccessKey    *string       `json:"accessKey,omitempty"`
+	ClientID     *string       `json:"clientId,omitempty"`
+	ClientKey    *string       `json:"clientKey,omitempty"`
+	Keyset       *KeysetConfig `json:"keyset,omitempty"`
 }
 
 // NewClientOptions represents options for creating a new client
@@ -133,7 +195,7 @@ type LockContext struct {
 
 // EncryptOptions represents options for encryption
 type EncryptOptions struct {
-	Plaintext         string       `json:"plaintext"`
+	Plaintext         interface{}  `json:"plaintext"`
 	Column            string       `json:"column"`
 	Table             string       `json:"table"`
 	LockContext       *LockContext `json:"lockContext,omitempty"`
@@ -143,7 +205,7 @@ type EncryptOptions struct {
 
 // PlaintextPayload represents a single plaintext item for bulk encryption
 type PlaintextPayload struct {
-	Plaintext   string       `json:"plaintext"`
+	Plaintext   interface{}  `json:"plaintext"`
 	Column      string       `json:"column"`
 	Table       string       `json:"table"`
 	LockContext *LockContext `json:"lockContext,omitempty"`
@@ -158,7 +220,7 @@ type EncryptBulkOptions struct {
 
 // DecryptOptions represents options for decryption
 type DecryptOptions struct {
-	Ciphertext        string       `json:"ciphertext"`
+	Ciphertext        *Encrypted   `json:"ciphertext"`
 	LockContext       *LockContext `json:"lockContext,omitempty"`
 	ServiceToken      *string      `json:"serviceToken,omitempty"`
 	UnverifiedContext interface{}  `json:"unverifiedContext,omitempty"`
@@ -166,7 +228,7 @@ type DecryptOptions struct {
 
 // BulkDecryptPayload represents a single ciphertext item for bulk decryption
 type BulkDecryptPayload struct {
-	Ciphertext  string       `json:"ciphertext"`
+	Ciphertext  *Encrypted   `json:"ciphertext"`
 	LockContext *LockContext `json:"lockContext,omitempty"`
 }
 
@@ -179,22 +241,67 @@ type DecryptBulkOptions struct {
 
 // Encrypted represents an encrypted value with its metadata
 type Encrypted struct {
-	Kind string `json:"k"`
-	// For ciphertext type
-	Ciphertext  *string    `json:"c,omitempty"`
-	OreIndex    *[]string  `json:"ob,omitempty"`
-	MatchIndex  *[]uint16  `json:"bf,omitempty"`
-	UniqueIndex *string    `json:"hm,omitempty"`
-	Identifier  Identifier `json:"i"`
-	Version     uint16     `json:"v"`
-	// For SteVec type
+	Identifier  Identifier  `json:"i"`
+	Version     uint16      `json:"v"`
+	Ciphertext  *string     `json:"c,omitempty"`
+	OreIndex    *[]string   `json:"ob,omitempty"`
+	MatchIndex  *[]uint16   `json:"bf,omitempty"`
+	UniqueIndex *string     `json:"hm,omitempty"`
 	SteVecIndex interface{} `json:"sv,omitempty"`
 }
 
 // DecryptResult represents the result of a fallible decryption operation
 type DecryptResult struct {
-	Data  *string `json:"data,omitempty"`
-	Error *string `json:"error,omitempty"`
+	Data  interface{} `json:"data,omitempty"`
+	Error *string     `json:"error,omitempty"`
+}
+
+// QueryOp represents the type of query operation for encrypted search
+type QueryOp string
+
+const (
+	QueryOpDefault        QueryOp = "default"
+	QueryOpSteVecSelector QueryOp = "ste_vec_selector"
+	QueryOpSteVecTerm     QueryOp = "ste_vec_term"
+)
+
+// IndexType represents the type of index to use for encrypted search
+type IndexType string
+
+const (
+	IndexTypeOre    IndexType = "ore"
+	IndexTypeUnique IndexType = "unique"
+	IndexTypeMatch  IndexType = "match"
+	IndexTypeSteVec IndexType = "ste_vec"
+)
+
+// EncryptQueryOptions represents options for encrypting a query value
+type EncryptQueryOptions struct {
+	Plaintext         interface{}  `json:"plaintext"`
+	Column            string       `json:"column"`
+	Table             string       `json:"table"`
+	IndexType         IndexType    `json:"indexType"`
+	QueryOp           QueryOp      `json:"queryOp,omitempty"`
+	LockContext       *LockContext `json:"lockContext,omitempty"`
+	ServiceToken      *string      `json:"serviceToken,omitempty"`
+	UnverifiedContext interface{}  `json:"unverifiedContext,omitempty"`
+}
+
+// QueryPayload represents a single query item for bulk query encryption
+type QueryPayload struct {
+	Plaintext   interface{}  `json:"plaintext"`
+	Column      string       `json:"column"`
+	Table       string       `json:"table"`
+	IndexType   IndexType    `json:"indexType"`
+	QueryOp     QueryOp      `json:"queryOp,omitempty"`
+	LockContext *LockContext `json:"lockContext,omitempty"`
+}
+
+// EncryptQueryBulkOptions represents options for bulk query encryption
+type EncryptQueryBulkOptions struct {
+	Queries           []QueryPayload `json:"queries"`
+	ServiceToken      *string        `json:"serviceToken,omitempty"`
+	UnverifiedContext interface{}    `json:"unverifiedContext,omitempty"`
 }
 
 // NewClient creates a new protect FFI client
@@ -212,7 +319,7 @@ func NewClient(options NewClientOptions) (*Client, error) {
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, errors.New(errorStr)
+		return nil, newEncryptionError(errorStr)
 	}
 
 	return &Client{ptr: unsafe.Pointer(result.data)}, nil
@@ -229,7 +336,7 @@ func (c *Client) Free() {
 // Encrypt encrypts a single plaintext value
 func (c *Client) Encrypt(options EncryptOptions) (*Encrypted, error) {
 	if c.ptr == nil {
-		return nil, errors.New("client has been freed")
+		return nil, newEncryptionError("client has been freed")
 	}
 
 	optionsJSON, err := json.Marshal(options)
@@ -245,7 +352,7 @@ func (c *Client) Encrypt(options EncryptOptions) (*Encrypted, error) {
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, errors.New(errorStr)
+		return nil, newEncryptionError(errorStr)
 	}
 
 	encryptedJSON := C.GoString(result.data)
@@ -262,7 +369,7 @@ func (c *Client) Encrypt(options EncryptOptions) (*Encrypted, error) {
 // EncryptBulk encrypts multiple plaintext values
 func (c *Client) EncryptBulk(options EncryptBulkOptions) ([]Encrypted, error) {
 	if c.ptr == nil {
-		return nil, errors.New("client has been freed")
+		return nil, newEncryptionError("client has been freed")
 	}
 
 	optionsJSON, err := json.Marshal(options)
@@ -278,7 +385,73 @@ func (c *Client) EncryptBulk(options EncryptBulkOptions) ([]Encrypted, error) {
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, errors.New(errorStr)
+		return nil, newEncryptionError(errorStr)
+	}
+
+	encryptedJSON := C.GoString(result.data)
+	C.protect_free_string(result.data)
+
+	var encrypted []Encrypted
+	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
+		return nil, err
+	}
+
+	return encrypted, nil
+}
+
+// EncryptQuery encrypts a value for searching against encrypted columns
+func (c *Client) EncryptQuery(options EncryptQueryOptions) (*Encrypted, error) {
+	if c.ptr == nil {
+		return nil, newEncryptionError("client has been freed")
+	}
+
+	optionsJSON, err := json.Marshal(options)
+	if err != nil {
+		return nil, err
+	}
+
+	cOptionsJSON := C.CString(string(optionsJSON))
+	defer C.free(unsafe.Pointer(cOptionsJSON))
+
+	result := C.protect_encrypt_query((*C.struct_Client)(c.ptr), cOptionsJSON)
+
+	if !result.success {
+		errorStr := C.GoString(result.error)
+		C.protect_free_string(result.error)
+		return nil, newEncryptionError(errorStr)
+	}
+
+	encryptedJSON := C.GoString(result.data)
+	C.protect_free_string(result.data)
+
+	var encrypted Encrypted
+	if err := json.Unmarshal([]byte(encryptedJSON), &encrypted); err != nil {
+		return nil, err
+	}
+
+	return &encrypted, nil
+}
+
+// EncryptQueryBulk encrypts multiple values for searching against encrypted columns
+func (c *Client) EncryptQueryBulk(options EncryptQueryBulkOptions) ([]Encrypted, error) {
+	if c.ptr == nil {
+		return nil, newEncryptionError("client has been freed")
+	}
+
+	optionsJSON, err := json.Marshal(options)
+	if err != nil {
+		return nil, err
+	}
+
+	cOptionsJSON := C.CString(string(optionsJSON))
+	defer C.free(unsafe.Pointer(cOptionsJSON))
+
+	result := C.protect_encrypt_query_bulk((*C.struct_Client)(c.ptr), cOptionsJSON)
+
+	if !result.success {
+		errorStr := C.GoString(result.error)
+		C.protect_free_string(result.error)
+		return nil, newEncryptionError(errorStr)
 	}
 
 	encryptedJSON := C.GoString(result.data)
@@ -293,14 +466,14 @@ func (c *Client) EncryptBulk(options EncryptBulkOptions) ([]Encrypted, error) {
 }
 
 // Decrypt decrypts a single ciphertext value
-func (c *Client) Decrypt(options DecryptOptions) (string, error) {
+func (c *Client) Decrypt(options DecryptOptions) (interface{}, error) {
 	if c.ptr == nil {
-		return "", errors.New("client has been freed")
+		return nil, newEncryptionError("client has been freed")
 	}
 
 	optionsJSON, err := json.Marshal(options)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	cOptionsJSON := C.CString(string(optionsJSON))
@@ -311,19 +484,24 @@ func (c *Client) Decrypt(options DecryptOptions) (string, error) {
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return "", errors.New(errorStr)
+		return nil, newEncryptionError(errorStr)
 	}
 
-	plaintext := C.GoString(result.data)
+	plaintextJSON := C.GoString(result.data)
 	C.protect_free_string(result.data)
+
+	var plaintext interface{}
+	if err := json.Unmarshal([]byte(plaintextJSON), &plaintext); err != nil {
+		return nil, err
+	}
 
 	return plaintext, nil
 }
 
 // DecryptBulk decrypts multiple ciphertext values
-func (c *Client) DecryptBulk(options DecryptBulkOptions) ([]string, error) {
+func (c *Client) DecryptBulk(options DecryptBulkOptions) ([]interface{}, error) {
 	if c.ptr == nil {
-		return nil, errors.New("client has been freed")
+		return nil, newEncryptionError("client has been freed")
 	}
 
 	optionsJSON, err := json.Marshal(options)
@@ -339,13 +517,13 @@ func (c *Client) DecryptBulk(options DecryptBulkOptions) ([]string, error) {
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, errors.New(errorStr)
+		return nil, newEncryptionError(errorStr)
 	}
 
 	plaintextJSON := C.GoString(result.data)
 	C.protect_free_string(result.data)
 
-	var plaintexts []string
+	var plaintexts []interface{}
 	if err := json.Unmarshal([]byte(plaintextJSON), &plaintexts); err != nil {
 		return nil, err
 	}
@@ -356,7 +534,7 @@ func (c *Client) DecryptBulk(options DecryptBulkOptions) ([]string, error) {
 // DecryptBulkFallible decrypts multiple ciphertext values with individual error handling
 func (c *Client) DecryptBulkFallible(options DecryptBulkOptions) ([]DecryptResult, error) {
 	if c.ptr == nil {
-		return nil, errors.New("client has been freed")
+		return nil, newEncryptionError("client has been freed")
 	}
 
 	optionsJSON, err := json.Marshal(options)
@@ -372,7 +550,7 @@ func (c *Client) DecryptBulkFallible(options DecryptBulkOptions) ([]DecryptResul
 	if !result.success {
 		errorStr := C.GoString(result.error)
 		C.protect_free_string(result.error)
-		return nil, errors.New(errorStr)
+		return nil, newEncryptionError(errorStr)
 	}
 
 	resultsJSON := C.GoString(result.data)
@@ -384,4 +562,18 @@ func (c *Client) DecryptBulkFallible(options DecryptBulkOptions) ([]DecryptResul
 	}
 
 	return results, nil
+}
+
+// IsEncrypted checks if a value is a valid encrypted payload.
+// This is a standalone function that does not require a Client.
+func IsEncrypted(value interface{}) bool {
+	valueJSON, err := json.Marshal(value)
+	if err != nil {
+		return false
+	}
+
+	cValueJSON := C.CString(string(valueJSON))
+	defer C.free(unsafe.Pointer(cValueJSON))
+
+	return bool(C.protect_is_encrypted(cValueJSON))
 }

--- a/pkg/protect/protect_ffi.h
+++ b/pkg/protect/protect_ffi.h
@@ -12,6 +12,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+/**
+ * Opaque client handle passed across the FFI boundary.
+ */
 typedef struct Client Client;
 
 typedef struct CResult {
@@ -24,9 +27,16 @@ typedef struct CResult {
 
  struct CResult protect_encrypt(const struct Client *client_ptr, const char *options_json) ;
 
- struct CResult protect_decrypt(const struct Client *client_ptr, const char *options_json) ;
-
  struct CResult protect_encrypt_bulk(const struct Client *client_ptr, const char *options_json) ;
+
+ struct CResult protect_encrypt_query(const struct Client *client_ptr, const char *options_json) ;
+
+
+struct CResult protect_encrypt_query_bulk(const struct Client *client_ptr,
+                                          const char *options_json)
+;
+
+ struct CResult protect_decrypt(const struct Client *client_ptr, const char *options_json) ;
 
  struct CResult protect_decrypt_bulk(const struct Client *client_ptr, const char *options_json) ;
 
@@ -34,6 +44,11 @@ typedef struct CResult {
 struct CResult protect_decrypt_bulk_fallible(const struct Client *client_ptr,
                                              const char *options_json)
 ;
+
+/**
+ * Check if a JSON value is a valid EQL ciphertext.
+ */
+ bool protect_is_encrypted(const char *value_json) ;
 
  void protect_free_client(const struct Client *client_ptr) ;
 

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -6,22 +6,27 @@ import (
 	"testing"
 )
 
-// TestIdentifier tests the Identifier creation and JSON marshaling
+// ---------------------------------------------------------------------------
+// Identifier tests
+// ---------------------------------------------------------------------------
+
 func TestIdentifier(t *testing.T) {
-	ident := NewIdentifier("users", "email")
+	t.Parallel()
+
+	ident := Identifier{Table: "users", Column: "email"}
 
 	if ident.Table != "users" {
-		t.Errorf("Expected table 'users', got '%s'", ident.Table)
+		t.Errorf("Expected table 'users', got %q", ident.Table)
 	}
-
 	if ident.Column != "email" {
-		t.Errorf("Expected column 'email', got '%s'", ident.Column)
+		t.Errorf("Expected column 'email', got %q", ident.Column)
 	}
 }
 
-// TestIdentifierJSON tests JSON serialization of Identifier
 func TestIdentifierJSON(t *testing.T) {
-	ident := NewIdentifier("users", "email")
+	t.Parallel()
+
+	ident := Identifier{Table: "users", Column: "email"}
 
 	data, err := json.Marshal(ident)
 	if err != nil {
@@ -38,65 +43,13 @@ func TestIdentifierJSON(t *testing.T) {
 	}
 }
 
-// TestEncryptConfigStructure tests the configuration structure
-func TestEncryptConfigStructure(t *testing.T) {
-	castAs := CastAsText
-	config := EncryptConfig{
-		Version: 1,
-		Tables: Tables{
-			"users": Table{
-				"email": Column{
-					CastAs: &castAs,
-					Indexes: &Indexes{
-						OreIndex: &OreIndexOpts{},
-						UniqueIndex: &UniqueIndexOpts{
-							TokenFilters: []TokenFilter{
-								{Kind: "downcase"},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+// ---------------------------------------------------------------------------
+// CastAs tests
+// ---------------------------------------------------------------------------
 
-	if config.Version != 1 {
-		t.Errorf("Expected version 1, got %d", config.Version)
-	}
-
-	usersTable, exists := config.Tables["users"]
-	if !exists {
-		t.Fatal("Expected 'users' table to exist")
-	}
-
-	emailColumn, exists := usersTable["email"]
-	if !exists {
-		t.Fatal("Expected 'email' column to exist")
-	}
-
-	if *emailColumn.CastAs != CastAsText {
-		t.Errorf("Expected CastAsText, got %v", *emailColumn.CastAs)
-	}
-
-	if emailColumn.Indexes.OreIndex == nil {
-		t.Error("Expected OreIndex to be configured")
-	}
-
-	if emailColumn.Indexes.UniqueIndex == nil {
-		t.Error("Expected UniqueIndex to be configured")
-	}
-
-	if len(emailColumn.Indexes.UniqueIndex.TokenFilters) != 1 {
-		t.Errorf("Expected 1 token filter, got %d", len(emailColumn.Indexes.UniqueIndex.TokenFilters))
-	}
-
-	if emailColumn.Indexes.UniqueIndex.TokenFilters[0].Kind != "downcase" {
-		t.Errorf("Expected 'downcase' token filter, got '%s'", emailColumn.Indexes.UniqueIndex.TokenFilters[0].Kind)
-	}
-}
-
-// TestCastAsConstants tests the CastAs constants
 func TestCastAsConstants(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		constant CastAs
@@ -112,7 +65,9 @@ func TestCastAsConstants(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			if string(tc.constant) != tc.expected {
 				t.Errorf("Expected %s, got %s", tc.expected, string(tc.constant))
 			}
@@ -120,467 +75,307 @@ func TestCastAsConstants(t *testing.T) {
 	}
 }
 
-// TestEncryptOptions tests the encrypt options structure
-func TestEncryptOptions(t *testing.T) {
-	lockContext := &LockContext{
-		IdentityClaim: []string{"user:123"},
-	}
+// ---------------------------------------------------------------------------
+// QueryType tests
+// ---------------------------------------------------------------------------
 
-	opts := EncryptOptions{
-		Plaintext:   "test@example.com",
-		Column:      "email",
-		Table:       "users",
-		LockContext: lockContext,
-	}
+func TestQueryTypeConstants(t *testing.T) {
+	t.Parallel()
 
-	if opts.Plaintext != "test@example.com" {
-		t.Errorf("Expected plaintext 'test@example.com', got '%v'", opts.Plaintext)
-	}
-
-	if opts.Column != "email" {
-		t.Errorf("Expected column 'email', got '%s'", opts.Column)
-	}
-
-	if opts.Table != "users" {
-		t.Errorf("Expected table 'users', got '%s'", opts.Table)
-	}
-
-	if opts.LockContext == nil {
-		t.Fatal("Expected LockContext to be set")
-	}
-
-	if len(opts.LockContext.IdentityClaim) != 1 {
-		t.Errorf("Expected 1 identity claim, got %d", len(opts.LockContext.IdentityClaim))
-	}
-
-	if opts.LockContext.IdentityClaim[0] != "user:123" {
-		t.Errorf("Expected 'user:123', got '%s'", opts.LockContext.IdentityClaim[0])
-	}
-}
-
-// TestEncryptOptionsMultiType tests that EncryptOptions accepts multiple plaintext types
-func TestEncryptOptionsMultiType(t *testing.T) {
 	tests := []struct {
-		name      string
-		plaintext interface{}
+		name     string
+		constant QueryType
+		expected string
 	}{
-		{"string", "hello world"},
-		{"number_int", 42},
-		{"number_float", 3.14},
-		{"boolean_true", true},
-		{"boolean_false", false},
-		{"json_object", map[string]interface{}{"key": "value"}},
-		{"json_array", []interface{}{"a", "b", "c"}},
-		{"nil", nil},
+		{"Equality", Equality, "unique"},
+		{"FreeTextSearch", FreeTextSearch, "match"},
+		{"OrderAndRange", OrderAndRange, "ore"},
+		{"JSONSelector", JSONSelector, "ste_vec_selector"},
+		{"JSONContains", JSONContains, "ste_vec_term"},
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			opts := EncryptOptions{
-				Plaintext: tc.plaintext,
-				Column:    "data",
-				Table:     "test",
-			}
-
-			data, err := json.Marshal(opts)
-			if err != nil {
-				t.Fatalf("Failed to marshal EncryptOptions with %s plaintext: %v", tc.name, err)
-			}
-
-			var decoded map[string]interface{}
-			if err := json.Unmarshal(data, &decoded); err != nil {
-				t.Fatalf("Failed to unmarshal EncryptOptions: %v", err)
-			}
-
-			if _, exists := decoded["plaintext"]; !exists && tc.plaintext != nil {
-				t.Error("Expected plaintext field in JSON output")
+			t.Parallel()
+			if string(tc.constant) != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, string(tc.constant))
 			}
 		})
 	}
 }
 
-// TestBulkEncryptOptions tests the bulk encrypt options structure
-func TestBulkEncryptOptions(t *testing.T) {
-	opts := EncryptBulkOptions{
-		Plaintexts: []PlaintextPayload{
-			{
-				Plaintext: "alice@example.com",
-				Column:    "email",
-				Table:     "users",
-			},
-			{
-				Plaintext: 42,
-				Column:    "age",
-				Table:     "users",
-			},
+// ---------------------------------------------------------------------------
+// resolveQueryType tests
+// ---------------------------------------------------------------------------
+
+func TestResolveQueryType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		queryType     QueryType
+		wantIndexType string
+		wantQueryOp   string
+	}{
+		{"Equality", Equality, "unique", "default"},
+		{"FreeTextSearch", FreeTextSearch, "match", "default"},
+		{"OrderAndRange", OrderAndRange, "ore", "default"},
+		{"JSONSelector", JSONSelector, "ste_vec", "ste_vec_selector"},
+		{"JSONContains", JSONContains, "ste_vec", "ste_vec_term"},
+		{"Unknown", QueryType("custom"), "custom", "default"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			indexType, queryOp := resolveQueryType(tc.queryType)
+			if indexType != tc.wantIndexType {
+				t.Errorf("indexType: got %q, want %q", indexType, tc.wantIndexType)
+			}
+			if queryOp != tc.wantQueryOp {
+				t.Errorf("queryOp: got %q, want %q", queryOp, tc.wantQueryOp)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ColumnRef tests
+// ---------------------------------------------------------------------------
+
+func TestColumnRefFromTableDef(t *testing.T) {
+	t.Parallel()
+
+	td := &TableDef{
+		name: "users",
+		columns: map[string]Column{
+			"email": {CastAs: castPtr(CastAsString)},
+			"age":   {CastAs: castPtr(CastAsNumber)},
 		},
 	}
 
-	if len(opts.Plaintexts) != 2 {
-		t.Errorf("Expected 2 plaintexts, got %d", len(opts.Plaintexts))
+	col := td.Column("email")
+	if col.table != "users" {
+		t.Errorf("table: got %q, want %q", col.table, "users")
 	}
-
-	if opts.Plaintexts[0].Plaintext != "alice@example.com" {
-		t.Errorf("Expected 'alice@example.com', got '%v'", opts.Plaintexts[0].Plaintext)
-	}
-
-	if opts.Plaintexts[1].Plaintext != 42 {
-		t.Errorf("Expected 42, got '%v'", opts.Plaintexts[1].Plaintext)
+	if col.column != "email" {
+		t.Errorf("column: got %q, want %q", col.column, "email")
 	}
 }
 
-// TestDecryptOptions tests the decrypt options structure with Encrypted ciphertext
-func TestDecryptOptions(t *testing.T) {
-	ct := "encrypted-data"
-	encrypted := &Encrypted{
-		Identifier: NewIdentifier("users", "email"),
-		Version:    1,
-		Ciphertext: &ct,
+func TestColumnRefPanicsOnUnknownColumn(t *testing.T) {
+	t.Parallel()
+
+	td := &TableDef{
+		name: "users",
+		columns: map[string]Column{
+			"email": {CastAs: castPtr(CastAsString)},
+		},
 	}
 
-	opts := DecryptOptions{
-		Ciphertext: encrypted,
-	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for unknown column")
+		}
+	}()
+	td.Column("nonexistent")
+}
 
-	if opts.Ciphertext == nil {
-		t.Fatal("Expected Ciphertext to be set")
-	}
+// ---------------------------------------------------------------------------
+// ClientOption tests
+// ---------------------------------------------------------------------------
 
-	if opts.Ciphertext.Version != 1 {
-		t.Errorf("Expected version 1, got %d", opts.Ciphertext.Version)
-	}
+func TestWithSchemas(t *testing.T) {
+	t.Parallel()
 
-	if *opts.Ciphertext.Ciphertext != "encrypted-data" {
-		t.Errorf("Expected 'encrypted-data', got '%s'", *opts.Ciphertext.Ciphertext)
+	td1 := &TableDef{name: "users", columns: map[string]Column{}}
+	td2 := &TableDef{name: "orders", columns: map[string]Column{}}
+
+	cfg := &clientConfig{}
+	WithSchemas(td1, td2)(cfg)
+
+	if len(cfg.schemas) != 2 {
+		t.Fatalf("schemas count: got %d, want 2", len(cfg.schemas))
+	}
+	if cfg.schemas[0].name != "users" {
+		t.Errorf("schema[0]: got %q, want %q", cfg.schemas[0].name, "users")
+	}
+	if cfg.schemas[1].name != "orders" {
+		t.Errorf("schema[1]: got %q, want %q", cfg.schemas[1].name, "orders")
 	}
 }
 
-// TestDecryptOptionsJSON tests JSON serialization of DecryptOptions
-func TestDecryptOptionsJSON(t *testing.T) {
-	ct := "encrypted-data"
-	encrypted := &Encrypted{
-		Identifier: NewIdentifier("users", "email"),
-		Version:    1,
-		Ciphertext: &ct,
-	}
+func TestWithCredentials(t *testing.T) {
+	t.Parallel()
 
-	opts := DecryptOptions{
-		Ciphertext: encrypted,
-	}
+	cfg := &clientConfig{}
+	WithCredentials("crn", "key", "id", "secret")(cfg)
 
-	data, err := json.Marshal(opts)
-	if err != nil {
-		t.Fatalf("Failed to marshal DecryptOptions: %v", err)
+	if cfg.workspaceCRN != "crn" {
+		t.Errorf("workspaceCRN: got %q, want %q", cfg.workspaceCRN, "crn")
 	}
-
-	var decoded map[string]interface{}
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatalf("Failed to unmarshal DecryptOptions: %v", err)
+	if cfg.accessKey != "key" {
+		t.Errorf("accessKey: got %q, want %q", cfg.accessKey, "key")
 	}
+	if cfg.clientID != "id" {
+		t.Errorf("clientID: got %q, want %q", cfg.clientID, "id")
+	}
+	if cfg.clientKey != "secret" {
+		t.Errorf("clientKey: got %q, want %q", cfg.clientKey, "secret")
+	}
+}
 
-	ciphertext, ok := decoded["ciphertext"].(map[string]interface{})
+func TestWithKeyset(t *testing.T) {
+	t.Parallel()
+
+	cfg := &clientConfig{}
+	WithKeyset("tenant-a")(cfg)
+
+	if cfg.keysetName != "tenant-a" {
+		t.Errorf("keysetName: got %q, want %q", cfg.keysetName, "tenant-a")
+	}
+}
+
+func TestWithKeysetID(t *testing.T) {
+	t.Parallel()
+
+	cfg := &clientConfig{}
+	WithKeysetID("ks-123")(cfg)
+
+	if cfg.keysetID != "ks-123" {
+		t.Errorf("keysetID: got %q, want %q", cfg.keysetID, "ks-123")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Operation Option tests
+// ---------------------------------------------------------------------------
+
+func TestWithLockContext(t *testing.T) {
+	t.Parallel()
+
+	lc := &LockContext{IdentityClaim: []string{"user:123"}}
+	co := buildCallOpts([]Option{WithLockContext(lc)})
+
+	if co.lockContext == nil {
+		t.Fatal("lockContext: expected non-nil")
+	}
+	if len(co.lockContext.IdentityClaim) != 1 || co.lockContext.IdentityClaim[0] != "user:123" {
+		t.Errorf("lockContext.IdentityClaim: got %v, want [user:123]", co.lockContext.IdentityClaim)
+	}
+}
+
+func TestWithServiceToken(t *testing.T) {
+	t.Parallel()
+
+	co := buildCallOpts([]Option{WithServiceToken("tok-abc")})
+
+	if co.serviceToken == nil || *co.serviceToken != "tok-abc" {
+		t.Errorf("serviceToken: got %v, want %q", co.serviceToken, "tok-abc")
+	}
+}
+
+func TestWithAuditContext(t *testing.T) {
+	t.Parallel()
+
+	audit := map[string]string{"action": "test"}
+	co := buildCallOpts([]Option{WithAuditContext(audit)})
+
+	if co.unverifiedContext == nil {
+		t.Fatal("unverifiedContext: expected non-nil")
+	}
+	m, ok := co.unverifiedContext.(map[string]string)
 	if !ok {
-		t.Fatal("Expected ciphertext to be an object")
+		t.Fatalf("unverifiedContext: expected map[string]string, got %T", co.unverifiedContext)
 	}
-
-	if ciphertext["c"] != "encrypted-data" {
-		t.Errorf("Expected ciphertext.c to be 'encrypted-data', got '%v'", ciphertext["c"])
-	}
-}
-
-// TestBulkDecryptPayload tests the bulk decrypt payload with Encrypted ciphertext
-func TestBulkDecryptPayload(t *testing.T) {
-	ct := "encrypted-data"
-	encrypted := &Encrypted{
-		Identifier: NewIdentifier("users", "email"),
-		Version:    1,
-		Ciphertext: &ct,
-	}
-
-	payload := BulkDecryptPayload{
-		Ciphertext: encrypted,
-	}
-
-	if payload.Ciphertext == nil {
-		t.Fatal("Expected Ciphertext to be set")
-	}
-
-	if *payload.Ciphertext.Ciphertext != "encrypted-data" {
-		t.Errorf("Expected 'encrypted-data', got '%s'", *payload.Ciphertext.Ciphertext)
+	if m["action"] != "test" {
+		t.Errorf("unverifiedContext[action]: got %q, want %q", m["action"], "test")
 	}
 }
 
-// TestDecryptResult tests the decrypt result structure with interface{} data
-func TestDecryptResult(t *testing.T) {
-	t.Run("string data", func(t *testing.T) {
-		result := DecryptResult{
-			Data: "decrypted data",
-		}
+func TestBuildCallOptsEmpty(t *testing.T) {
+	t.Parallel()
 
-		if result.Data == nil {
-			t.Error("Expected data to be set")
-		}
+	co := buildCallOpts(nil)
 
-		if result.Data != "decrypted data" {
-			t.Errorf("Expected 'decrypted data', got '%v'", result.Data)
-		}
-
-		if result.Error != nil {
-			t.Error("Expected error to be nil for successful result")
-		}
-	})
-
-	t.Run("numeric data", func(t *testing.T) {
-		result := DecryptResult{
-			Data: 42.0,
-		}
-
-		if result.Data != 42.0 {
-			t.Errorf("Expected 42.0, got '%v'", result.Data)
-		}
-	})
-
-	t.Run("boolean data", func(t *testing.T) {
-		result := DecryptResult{
-			Data: true,
-		}
-
-		if result.Data != true {
-			t.Errorf("Expected true, got '%v'", result.Data)
-		}
-	})
-
-	t.Run("nil data", func(t *testing.T) {
-		result := DecryptResult{
-			Data: nil,
-		}
-
-		if result.Data != nil {
-			t.Error("Expected data to be nil")
-		}
-	})
-
-	t.Run("error result", func(t *testing.T) {
-		errorMsg := "decryption failed"
-		result := DecryptResult{
-			Error: &errorMsg,
-		}
-
-		if result.Error == nil {
-			t.Error("Expected error to be set")
-		}
-
-		if *result.Error != "decryption failed" {
-			t.Errorf("Expected 'decryption failed', got '%s'", *result.Error)
-		}
-
-		if result.Data != nil {
-			t.Error("Expected data to be nil for error result")
-		}
-	})
-}
-
-// TestDecryptResultJSON tests JSON round-trip of DecryptResult with multi-type data
-func TestDecryptResultJSON(t *testing.T) {
-	tests := []struct {
-		name string
-		json string
-	}{
-		{"string", `{"data":"hello"}`},
-		{"number", `{"data":42}`},
-		{"boolean", `{"data":true}`},
-		{"null", `{"data":null}`},
-		{"error", `{"error":"failed"}`},
+	if co.lockContext != nil {
+		t.Error("lockContext: expected nil")
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var result DecryptResult
-			if err := json.Unmarshal([]byte(tc.json), &result); err != nil {
-				t.Fatalf("Failed to unmarshal: %v", err)
-			}
-		})
+	if co.serviceToken != nil {
+		t.Error("serviceToken: expected nil")
+	}
+	if co.unverifiedContext != nil {
+		t.Error("unverifiedContext: expected nil")
 	}
 }
 
-// TestTokenizer tests the tokenizer structure
-func TestTokenizer(t *testing.T) {
-	// Test standard tokenizer
-	standardTokenizer := Tokenizer{
-		Kind: "standard",
-	}
+// ---------------------------------------------------------------------------
+// EncryptConfig building tests
+// ---------------------------------------------------------------------------
 
-	if standardTokenizer.Kind != "standard" {
-		t.Errorf("Expected 'standard', got '%s'", standardTokenizer.Kind)
-	}
+func TestBuildEncryptConfigFromSchemas(t *testing.T) {
+	t.Parallel()
 
-	if standardTokenizer.TokenLength != nil {
-		t.Error("Expected TokenLength to be nil for standard tokenizer")
-	}
-
-	// Test ngram tokenizer
-	tokenLength := 3
-	ngramTokenizer := Tokenizer{
-		Kind:        "ngram",
-		TokenLength: &tokenLength,
-	}
-
-	if ngramTokenizer.Kind != "ngram" {
-		t.Errorf("Expected 'ngram', got '%s'", ngramTokenizer.Kind)
-	}
-
-	if ngramTokenizer.TokenLength == nil {
-		t.Error("Expected TokenLength to be set for ngram tokenizer")
-	}
-
-	if *ngramTokenizer.TokenLength != 3 {
-		t.Errorf("Expected token length 3, got %d", *ngramTokenizer.TokenLength)
-	}
-}
-
-// TestMatchIndexOpts tests the match index options
-func TestMatchIndexOpts(t *testing.T) {
-	k := 8
-	m := 1024
-	includeOriginal := true
-
-	matchOpts := MatchIndexOpts{
-		Tokenizer: &Tokenizer{
-			Kind: "standard",
+	td := &TableDef{
+		name: "users",
+		columns: map[string]Column{
+			"email": {CastAs: castPtr(CastAsString)},
+			"age":   {CastAs: castPtr(CastAsNumber)},
 		},
-		TokenFilters: []TokenFilter{
-			{Kind: "downcase"},
-			{Kind: "trim"},
-		},
-		K:               &k,
-		M:               &m,
-		IncludeOriginal: &includeOriginal,
 	}
 
-	if matchOpts.Tokenizer == nil {
-		t.Error("Expected tokenizer to be set")
-	}
+	config := buildEncryptConfigFromSchemas([]*TableDef{td})
 
-	if matchOpts.Tokenizer.Kind != "standard" {
-		t.Errorf("Expected 'standard' tokenizer, got '%s'", matchOpts.Tokenizer.Kind)
+	if config.Version != 1 {
+		t.Errorf("version: got %d, want 1", config.Version)
 	}
-
-	if len(matchOpts.TokenFilters) != 2 {
-		t.Errorf("Expected 2 token filters, got %d", len(matchOpts.TokenFilters))
+	if len(config.Tables) != 1 {
+		t.Fatalf("tables: got %d, want 1", len(config.Tables))
 	}
-
-	if matchOpts.TokenFilters[0].Kind != "downcase" {
-		t.Errorf("Expected 'downcase', got '%s'", matchOpts.TokenFilters[0].Kind)
+	usersTable, ok := config.Tables["users"]
+	if !ok {
+		t.Fatal("missing users table")
 	}
-
-	if matchOpts.TokenFilters[1].Kind != "trim" {
-		t.Errorf("Expected 'trim', got '%s'", matchOpts.TokenFilters[1].Kind)
-	}
-
-	if matchOpts.K == nil || *matchOpts.K != 8 {
-		t.Errorf("Expected K to be 8, got %v", matchOpts.K)
-	}
-
-	if matchOpts.M == nil || *matchOpts.M != 1024 {
-		t.Errorf("Expected M to be 1024, got %v", matchOpts.M)
-	}
-
-	if matchOpts.IncludeOriginal == nil || *matchOpts.IncludeOriginal != true {
-		t.Errorf("Expected IncludeOriginal to be true, got %v", matchOpts.IncludeOriginal)
+	if len(usersTable) != 2 {
+		t.Errorf("user columns: got %d, want 2", len(usersTable))
 	}
 }
 
-// TestSteVecIndexOpts tests the SteVec index options with new fields
-func TestSteVecIndexOpts(t *testing.T) {
-	t.Run("basic", func(t *testing.T) {
-		opts := SteVecIndexOpts{
-			Prefix: "users",
-		}
+func TestBuildEncryptConfigFromSchemasMultiple(t *testing.T) {
+	t.Parallel()
 
-		if opts.Prefix != "users" {
-			t.Errorf("Expected prefix 'users', got '%s'", opts.Prefix)
-		}
+	td1 := &TableDef{name: "users", columns: map[string]Column{"email": {}}}
+	td2 := &TableDef{name: "orders", columns: map[string]Column{"total": {}}}
 
-		if opts.TermFilters != nil {
-			t.Error("Expected TermFilters to be nil")
-		}
+	config := buildEncryptConfigFromSchemas([]*TableDef{td1, td2})
 
-		if opts.ArrayIndexMode != nil {
-			t.Error("Expected ArrayIndexMode to be nil")
-		}
-	})
-
-	t.Run("with term filters and array index mode", func(t *testing.T) {
-		arrayMode := "flatten"
-		opts := SteVecIndexOpts{
-			Prefix: "products",
-			TermFilters: []TokenFilter{
-				{Kind: "downcase"},
-				{Kind: "trim"},
-			},
-			ArrayIndexMode: &arrayMode,
-		}
-
-		if opts.Prefix != "products" {
-			t.Errorf("Expected prefix 'products', got '%s'", opts.Prefix)
-		}
-
-		if len(opts.TermFilters) != 2 {
-			t.Errorf("Expected 2 term filters, got %d", len(opts.TermFilters))
-		}
-
-		if opts.TermFilters[0].Kind != "downcase" {
-			t.Errorf("Expected 'downcase', got '%s'", opts.TermFilters[0].Kind)
-		}
-
-		if opts.ArrayIndexMode == nil || *opts.ArrayIndexMode != "flatten" {
-			t.Errorf("Expected ArrayIndexMode 'flatten', got %v", opts.ArrayIndexMode)
-		}
-	})
-
-	t.Run("json round-trip", func(t *testing.T) {
-		arrayMode := "flatten"
-		opts := SteVecIndexOpts{
-			Prefix: "test",
-			TermFilters: []TokenFilter{
-				{Kind: "downcase"},
-			},
-			ArrayIndexMode: &arrayMode,
-		}
-
-		data, err := json.Marshal(opts)
-		if err != nil {
-			t.Fatalf("Failed to marshal: %v", err)
-		}
-
-		var decoded SteVecIndexOpts
-		if err := json.Unmarshal(data, &decoded); err != nil {
-			t.Fatalf("Failed to unmarshal: %v", err)
-		}
-
-		if decoded.Prefix != "test" {
-			t.Errorf("Expected prefix 'test', got '%s'", decoded.Prefix)
-		}
-
-		if len(decoded.TermFilters) != 1 {
-			t.Errorf("Expected 1 term filter, got %d", len(decoded.TermFilters))
-		}
-
-		if decoded.ArrayIndexMode == nil || *decoded.ArrayIndexMode != "flatten" {
-			t.Errorf("Expected ArrayIndexMode 'flatten', got %v", decoded.ArrayIndexMode)
-		}
-	})
+	if len(config.Tables) != 2 {
+		t.Fatalf("tables: got %d, want 2", len(config.Tables))
+	}
+	if _, ok := config.Tables["users"]; !ok {
+		t.Error("missing users table")
+	}
+	if _, ok := config.Tables["orders"]; !ok {
+		t.Error("missing orders table")
+	}
 }
 
-// TestEncryptedStruct tests the Encrypted struct without Kind field
+// ---------------------------------------------------------------------------
+// Encrypted struct tests
+// ---------------------------------------------------------------------------
+
 func TestEncryptedStruct(t *testing.T) {
+	t.Parallel()
+
 	ct := "ciphertext-value"
 	ore := []string{"ore1", "ore2"}
 	match := []uint16{1, 2, 3}
 	unique := "unique-hash"
 
 	encrypted := Encrypted{
-		Identifier:  NewIdentifier("users", "email"),
+		Identifier:  Identifier{Table: "users", Column: "email"},
 		Version:     1,
 		Ciphertext:  &ct,
 		OreIndex:    &ore,
@@ -589,23 +384,22 @@ func TestEncryptedStruct(t *testing.T) {
 	}
 
 	if encrypted.Identifier.Table != "users" {
-		t.Errorf("Expected table 'users', got '%s'", encrypted.Identifier.Table)
+		t.Errorf("Expected table 'users', got %q", encrypted.Identifier.Table)
 	}
-
 	if encrypted.Version != 1 {
 		t.Errorf("Expected version 1, got %d", encrypted.Version)
 	}
-
 	if *encrypted.Ciphertext != "ciphertext-value" {
-		t.Errorf("Expected 'ciphertext-value', got '%s'", *encrypted.Ciphertext)
+		t.Errorf("Expected 'ciphertext-value', got %q", *encrypted.Ciphertext)
 	}
 }
 
-// TestEncryptedJSON tests JSON serialization of Encrypted (no Kind field)
 func TestEncryptedJSON(t *testing.T) {
+	t.Parallel()
+
 	ct := "ciphertext-value"
 	encrypted := Encrypted{
-		Identifier: NewIdentifier("users", "email"),
+		Identifier: Identifier{Table: "users", Column: "email"},
 		Version:    1,
 		Ciphertext: &ct,
 	}
@@ -615,298 +409,112 @@ func TestEncryptedJSON(t *testing.T) {
 		t.Fatalf("Failed to marshal: %v", err)
 	}
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
 
-	// Verify Kind field is not present
-	if _, exists := decoded["k"]; exists {
-		t.Error("Expected 'k' (Kind) field to not be present in JSON output")
-	}
-
-	// Verify expected fields
 	if decoded["c"] != "ciphertext-value" {
-		t.Errorf("Expected c='ciphertext-value', got '%v'", decoded["c"])
+		t.Errorf("Expected c='ciphertext-value', got %v", decoded["c"])
 	}
-
-	// Version should be present
 	if decoded["v"] == nil {
 		t.Error("Expected 'v' field to be present")
 	}
 }
 
-// TestKeysetConfig tests the KeysetConfig structure
-func TestKeysetConfig(t *testing.T) {
-	t.Run("with name", func(t *testing.T) {
-		name := "my-keyset"
-		config := KeysetConfig{
-			Name: &name,
-		}
+func TestEncryptedJSONRoundTrip(t *testing.T) {
+	t.Parallel()
 
-		if config.Name == nil || *config.Name != "my-keyset" {
-			t.Errorf("Expected name 'my-keyset', got %v", config.Name)
-		}
+	ct := "cipher"
+	ore := []string{"a", "b"}
+	unique := "hmac"
 
-		if config.ID != nil {
-			t.Error("Expected ID to be nil")
-		}
-	})
-
-	t.Run("with id", func(t *testing.T) {
-		id := "keyset-123"
-		config := KeysetConfig{
-			ID: &id,
-		}
-
-		if config.ID == nil || *config.ID != "keyset-123" {
-			t.Errorf("Expected id 'keyset-123', got %v", config.ID)
-		}
-
-		if config.Name != nil {
-			t.Error("Expected Name to be nil")
-		}
-	})
-
-	t.Run("json omitempty", func(t *testing.T) {
-		name := "test"
-		config := KeysetConfig{
-			Name: &name,
-		}
-
-		data, err := json.Marshal(config)
-		if err != nil {
-			t.Fatalf("Failed to marshal: %v", err)
-		}
-
-		var decoded map[string]interface{}
-		if err := json.Unmarshal(data, &decoded); err != nil {
-			t.Fatalf("Failed to unmarshal: %v", err)
-		}
-
-		if _, exists := decoded["id"]; exists {
-			t.Error("Expected 'id' to be omitted when nil")
-		}
-	})
-}
-
-// TestClientOptsWithKeyset tests ClientOpts includes Keyset field
-func TestClientOptsWithKeyset(t *testing.T) {
-	keysetName := "my-keyset"
-	opts := ClientOpts{
-		Keyset: &KeysetConfig{
-			Name: &keysetName,
-		},
+	original := Encrypted{
+		Identifier:  Identifier{Table: "t", Column: "c"},
+		Version:     1,
+		Ciphertext:  &ct,
+		OreIndex:    &ore,
+		UniqueIndex: &unique,
 	}
 
-	data, err := json.Marshal(opts)
+	data, err := json.Marshal(original)
 	if err != nil {
-		t.Fatalf("Failed to marshal: %v", err)
+		t.Fatalf("Marshal failed: %v", err)
 	}
 
-	var decoded map[string]interface{}
+	var decoded Encrypted
 	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatalf("Failed to unmarshal: %v", err)
+		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
-	keyset, ok := decoded["keyset"].(map[string]interface{})
-	if !ok {
-		t.Fatal("Expected keyset to be an object")
+	if decoded.Identifier.Table != "t" || decoded.Identifier.Column != "c" {
+		t.Errorf("identifier: got t=%q c=%q", decoded.Identifier.Table, decoded.Identifier.Column)
 	}
-
-	if keyset["name"] != "my-keyset" {
-		t.Errorf("Expected keyset.name='my-keyset', got '%v'", keyset["name"])
+	if *decoded.Ciphertext != "cipher" {
+		t.Errorf("ciphertext: got %q, want %q", *decoded.Ciphertext, "cipher")
 	}
-}
-
-// TestQueryOpConstants tests the QueryOp constants
-func TestQueryOpConstants(t *testing.T) {
-	tests := []struct {
-		name     string
-		constant QueryOp
-		expected string
-	}{
-		{"Default", QueryOpDefault, "default"},
-		{"SteVecSelector", QueryOpSteVecSelector, "ste_vec_selector"},
-		{"SteVecTerm", QueryOpSteVecTerm, "ste_vec_term"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if string(tc.constant) != tc.expected {
-				t.Errorf("Expected %s, got %s", tc.expected, string(tc.constant))
-			}
-		})
+	if decoded.UniqueIndex == nil || *decoded.UniqueIndex != "hmac" {
+		t.Errorf("uniqueIndex: got %v, want %q", decoded.UniqueIndex, "hmac")
 	}
 }
 
-// TestIndexTypeConstants tests the IndexType constants
-func TestIndexTypeConstants(t *testing.T) {
-	tests := []struct {
-		name     string
-		constant IndexType
-		expected string
-	}{
-		{"Ore", IndexTypeOre, "ore"},
-		{"Unique", IndexTypeUnique, "unique"},
-		{"Match", IndexTypeMatch, "match"},
-		{"SteVec", IndexTypeSteVec, "ste_vec"},
-	}
+// ---------------------------------------------------------------------------
+// DecryptResult tests
+// ---------------------------------------------------------------------------
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if string(tc.constant) != tc.expected {
-				t.Errorf("Expected %s, got %s", tc.expected, string(tc.constant))
-			}
-		})
-	}
+func TestDecryptResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		r := DecryptResult{Data: "hello"}
+		if r.Data != "hello" {
+			t.Errorf("Data: got %v, want %q", r.Data, "hello")
+		}
+		if r.Err != nil {
+			t.Errorf("Err: got %v, want nil", r.Err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+		r := DecryptResult{Err: errors.New("failed")}
+		if r.Data != nil {
+			t.Errorf("Data: got %v, want nil", r.Data)
+		}
+		if r.Err == nil || r.Err.Error() != "failed" {
+			t.Errorf("Err: got %v, want 'failed'", r.Err)
+		}
+	})
+
+	t.Run("numeric data", func(t *testing.T) {
+		t.Parallel()
+		r := DecryptResult{Data: 42.0}
+		if r.Data != 42.0 {
+			t.Errorf("Data: got %v, want 42.0", r.Data)
+		}
+	})
+
+	t.Run("nil data", func(t *testing.T) {
+		t.Parallel()
+		r := DecryptResult{}
+		if r.Data != nil {
+			t.Errorf("Data: got %v, want nil", r.Data)
+		}
+	})
 }
 
-// TestEncryptQueryOptions tests the EncryptQueryOptions structure
-func TestEncryptQueryOptions(t *testing.T) {
-	opts := EncryptQueryOptions{
-		Plaintext: "search-term",
-		Column:    "email",
-		Table:     "users",
-		IndexType: IndexTypeMatch,
-		QueryOp:   QueryOpDefault,
-	}
+// ---------------------------------------------------------------------------
+// Error and sentinel tests
+// ---------------------------------------------------------------------------
 
-	if opts.Plaintext != "search-term" {
-		t.Errorf("Expected plaintext 'search-term', got '%v'", opts.Plaintext)
-	}
+func TestErrorSentinels(t *testing.T) {
+	t.Parallel()
 
-	if opts.IndexType != IndexTypeMatch {
-		t.Errorf("Expected IndexTypeMatch, got '%s'", opts.IndexType)
-	}
-
-	if opts.QueryOp != QueryOpDefault {
-		t.Errorf("Expected QueryOpDefault, got '%s'", opts.QueryOp)
-	}
-}
-
-// TestEncryptQueryOptionsJSON tests JSON serialization of EncryptQueryOptions
-func TestEncryptQueryOptionsJSON(t *testing.T) {
-	opts := EncryptQueryOptions{
-		Plaintext: "test",
-		Column:    "email",
-		Table:     "users",
-		IndexType: IndexTypeOre,
-	}
-
-	data, err := json.Marshal(opts)
-	if err != nil {
-		t.Fatalf("Failed to marshal: %v", err)
-	}
-
-	var decoded map[string]interface{}
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatalf("Failed to unmarshal: %v", err)
-	}
-
-	if decoded["indexType"] != "ore" {
-		t.Errorf("Expected indexType='ore', got '%v'", decoded["indexType"])
-	}
-
-	// queryOp should be omitted when zero value
-	if _, exists := decoded["queryOp"]; exists {
-		t.Error("Expected queryOp to be omitted when empty")
-	}
-}
-
-// TestQueryPayload tests the QueryPayload structure
-func TestQueryPayload(t *testing.T) {
-	payload := QueryPayload{
-		Plaintext: "search",
-		Column:    "name",
-		Table:     "users",
-		IndexType: IndexTypeSteVec,
-		QueryOp:   QueryOpSteVecTerm,
-	}
-
-	if payload.IndexType != IndexTypeSteVec {
-		t.Errorf("Expected IndexTypeSteVec, got '%s'", payload.IndexType)
-	}
-
-	if payload.QueryOp != QueryOpSteVecTerm {
-		t.Errorf("Expected QueryOpSteVecTerm, got '%s'", payload.QueryOp)
-	}
-}
-
-// TestEncryptQueryBulkOptions tests the EncryptQueryBulkOptions structure
-func TestEncryptQueryBulkOptions(t *testing.T) {
-	opts := EncryptQueryBulkOptions{
-		Queries: []QueryPayload{
-			{
-				Plaintext: "term1",
-				Column:    "email",
-				Table:     "users",
-				IndexType: IndexTypeMatch,
-			},
-			{
-				Plaintext: "term2",
-				Column:    "name",
-				Table:     "users",
-				IndexType: IndexTypeOre,
-			},
-		},
-	}
-
-	if len(opts.Queries) != 2 {
-		t.Errorf("Expected 2 queries, got %d", len(opts.Queries))
-	}
-
-	if opts.Queries[0].Plaintext != "term1" {
-		t.Errorf("Expected 'term1', got '%v'", opts.Queries[0].Plaintext)
-	}
-
-	if opts.Queries[1].IndexType != IndexTypeOre {
-		t.Errorf("Expected IndexTypeOre, got '%s'", opts.Queries[1].IndexType)
-	}
-}
-
-// TestEncryptionError tests the EncryptionError type
-func TestEncryptionError(t *testing.T) {
-	err := &EncryptionError{
-		Code:    ErrUnknownColumn,
-		Message: "column 'foo' not found in Encrypt config",
-	}
-
-	if err.Error() != "column 'foo' not found in Encrypt config" {
-		t.Errorf("Expected error message, got '%s'", err.Error())
-	}
-
-	if err.Code != ErrUnknownColumn {
-		t.Errorf("Expected ErrUnknownColumn, got '%s'", err.Code)
-	}
-
-	// Test that it implements the error interface
-	var e error = err
-	if e == nil {
-		t.Error("Expected non-nil error")
-	}
-}
-
-// TestEncryptionErrorUnwrap tests that EncryptionError can be matched with errors.As
-func TestEncryptionErrorUnwrap(t *testing.T) {
-	err := newEncryptionError("column 'foo' not found in Encrypt config")
-
-	var encErr *EncryptionError
-	if !errors.As(err, &encErr) {
-		t.Error("Expected errors.As to match EncryptionError")
-	}
-
-	if encErr.Code != ErrUnknownColumn {
-		t.Errorf("Expected ErrUnknownColumn, got '%s'", encErr.Code)
-	}
-}
-
-// TestInferErrorCode tests the error code inference from messages
-func TestInferErrorCode(t *testing.T) {
 	tests := []struct {
 		name     string
 		message  string
-		expected ErrorCode
+		sentinel error
 	}{
 		{
 			"invariant violation",
@@ -936,76 +544,323 @@ func TestInferErrorCode(t *testing.T) {
 		{
 			"invalid json path",
 			"Invalid JSON path: $.foo.bar",
-			ErrInvalidJsonPath,
+			ErrInvalidJSONPath,
 		},
 		{
-			"ste_vec requires json cast_as",
+			"ste_vec requires json",
 			"ste_vec index requires cast_as to be json",
-			ErrSteVecRequiresJsonCastAs,
-		},
-		{
-			"unknown error",
-			"something completely unexpected happened",
-			ErrUnknown,
+			ErrSteVecRequiresJSON,
 		},
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			code := inferErrorCode(tc.message)
-			if code != tc.expected {
-				t.Errorf("Expected %s, got %s", tc.expected, code)
+			t.Parallel()
+			err := newError("Test", tc.message)
+			if !errors.Is(err, tc.sentinel) {
+				t.Errorf("errors.Is(err, %v) = false, want true", tc.sentinel)
+			}
+			if err.Error() != tc.message {
+				t.Errorf("Error(): got %q, want %q", err.Error(), tc.message)
+			}
+			if err.Op != "Test" {
+				t.Errorf("Op: got %q, want %q", err.Op, "Test")
 			}
 		})
 	}
 }
 
-// TestNewEncryptionError tests the newEncryptionError constructor
-func TestNewEncryptionError(t *testing.T) {
-	err := newEncryptionError("column 'email' not found in Encrypt config")
+func TestErrorUnknownMessage(t *testing.T) {
+	t.Parallel()
 
-	if err.Code != ErrUnknownColumn {
-		t.Errorf("Expected ErrUnknownColumn, got '%s'", err.Code)
+	err := newError("Test", "something completely unexpected happened")
+
+	// Should not match any sentinel.
+	if errors.Is(err, ErrUnknownColumn) {
+		t.Error("should not match ErrUnknownColumn")
+	}
+	if errors.Is(err, ErrMissingIndex) {
+		t.Error("should not match ErrMissingIndex")
 	}
 
-	if err.Message != "column 'email' not found in Encrypt config" {
-		t.Errorf("Unexpected message: '%s'", err.Message)
+	// The wrapped Err should be nil.
+	var protectErr *Error
+	if !errors.As(err, &protectErr) {
+		t.Fatal("errors.As should match *Error")
+	}
+	if protectErr.Err != nil {
+		t.Errorf("Err: got %v, want nil", protectErr.Err)
 	}
 }
 
-// TestPlaintextPayloadMultiType tests PlaintextPayload with different types
-func TestPlaintextPayloadMultiType(t *testing.T) {
-	tests := []struct {
-		name      string
-		plaintext interface{}
-	}{
-		{"string", "hello"},
-		{"number", 42},
-		{"boolean", true},
-		{"json", map[string]interface{}{"nested": "value"}},
+func TestErrorClientClosed(t *testing.T) {
+	t.Parallel()
+
+	err := &Error{Op: "Encrypt", Err: ErrClientClosed, Message: "protect: client is closed"}
+
+	if !errors.Is(err, ErrClientClosed) {
+		t.Error("errors.Is(err, ErrClientClosed) = false, want true")
+	}
+	if err.Error() != "protect: client is closed" {
+		t.Errorf("Error(): got %q", err.Error())
+	}
+}
+
+func TestErrorImplementsErrorInterface(t *testing.T) {
+	t.Parallel()
+
+	var e error = &Error{Op: "Test", Message: "test error"}
+	if e.Error() != "test error" {
+		t.Errorf("Error(): got %q, want %q", e.Error(), "test error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer and index opts tests
+// ---------------------------------------------------------------------------
+
+func TestTokenizer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("standard", func(t *testing.T) {
+		t.Parallel()
+		tok := Tokenizer{Kind: "standard"}
+		if tok.Kind != "standard" {
+			t.Errorf("Kind: got %q, want %q", tok.Kind, "standard")
+		}
+		if tok.TokenLength != nil {
+			t.Error("TokenLength: expected nil")
+		}
+	})
+
+	t.Run("ngram", func(t *testing.T) {
+		t.Parallel()
+		tl := 3
+		tok := Tokenizer{Kind: "ngram", TokenLength: &tl}
+		if tok.Kind != "ngram" {
+			t.Errorf("Kind: got %q, want %q", tok.Kind, "ngram")
+		}
+		if tok.TokenLength == nil || *tok.TokenLength != 3 {
+			t.Errorf("TokenLength: got %v, want 3", tok.TokenLength)
+		}
+	})
+}
+
+func TestMatchIndexOpts(t *testing.T) {
+	t.Parallel()
+
+	k := 8
+	m := 1024
+	includeOriginal := true
+
+	opts := MatchIndexOpts{
+		Tokenizer:       &Tokenizer{Kind: "standard"},
+		TokenFilters:    []TokenFilter{{Kind: "downcase"}, {Kind: "trim"}},
+		K:               &k,
+		M:               &m,
+		IncludeOriginal: &includeOriginal,
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			payload := PlaintextPayload{
-				Plaintext: tc.plaintext,
-				Column:    "data",
-				Table:     "test",
-			}
-
-			data, err := json.Marshal(payload)
-			if err != nil {
-				t.Fatalf("Failed to marshal: %v", err)
-			}
-
-			var decoded map[string]interface{}
-			if err := json.Unmarshal(data, &decoded); err != nil {
-				t.Fatalf("Failed to unmarshal: %v", err)
-			}
-
-			if decoded["plaintext"] == nil {
-				t.Error("Expected plaintext to be present")
-			}
-		})
+	if opts.Tokenizer.Kind != "standard" {
+		t.Errorf("tokenizer kind: got %q, want %q", opts.Tokenizer.Kind, "standard")
 	}
+	if len(opts.TokenFilters) != 2 {
+		t.Errorf("token filters: got %d, want 2", len(opts.TokenFilters))
+	}
+	if *opts.K != 8 {
+		t.Errorf("K: got %d, want 8", *opts.K)
+	}
+	if *opts.M != 1024 {
+		t.Errorf("M: got %d, want 1024", *opts.M)
+	}
+}
+
+func TestSteVecIndexOpts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic", func(t *testing.T) {
+		t.Parallel()
+		opts := SteVecIndexOpts{Prefix: "users"}
+		if opts.Prefix != "users" {
+			t.Errorf("Prefix: got %q, want %q", opts.Prefix, "users")
+		}
+	})
+
+	t.Run("with term filters and array index mode", func(t *testing.T) {
+		t.Parallel()
+		mode := "flatten"
+		opts := SteVecIndexOpts{
+			Prefix:         "products",
+			TermFilters:    []TokenFilter{{Kind: "downcase"}},
+			ArrayIndexMode: &mode,
+		}
+		if opts.Prefix != "products" {
+			t.Errorf("Prefix: got %q, want %q", opts.Prefix, "products")
+		}
+		if len(opts.TermFilters) != 1 {
+			t.Errorf("TermFilters: got %d, want 1", len(opts.TermFilters))
+		}
+		if opts.ArrayIndexMode == nil || *opts.ArrayIndexMode != "flatten" {
+			t.Errorf("ArrayIndexMode: got %v, want %q", opts.ArrayIndexMode, "flatten")
+		}
+	})
+
+	t.Run("json round-trip", func(t *testing.T) {
+		t.Parallel()
+		mode := "flatten"
+		opts := SteVecIndexOpts{
+			Prefix:         "test",
+			TermFilters:    []TokenFilter{{Kind: "downcase"}},
+			ArrayIndexMode: &mode,
+		}
+
+		data, err := json.Marshal(opts)
+		if err != nil {
+			t.Fatalf("Marshal failed: %v", err)
+		}
+
+		var decoded SteVecIndexOpts
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal failed: %v", err)
+		}
+
+		if decoded.Prefix != "test" {
+			t.Errorf("Prefix: got %q, want %q", decoded.Prefix, "test")
+		}
+		if decoded.ArrayIndexMode == nil || *decoded.ArrayIndexMode != "flatten" {
+			t.Errorf("ArrayIndexMode: got %v, want %q", decoded.ArrayIndexMode, "flatten")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// PlaintextItem and QueryItem tests
+// ---------------------------------------------------------------------------
+
+func TestPlaintextItem(t *testing.T) {
+	t.Parallel()
+
+	col := ColumnRef{table: "users", column: "email"}
+	item := PlaintextItem{
+		Column:    col,
+		Plaintext: "alice@example.com",
+	}
+
+	if item.Column.table != "users" || item.Column.column != "email" {
+		t.Errorf("Column: got table=%q column=%q", item.Column.table, item.Column.column)
+	}
+	if item.Plaintext != "alice@example.com" {
+		t.Errorf("Plaintext: got %v, want %q", item.Plaintext, "alice@example.com")
+	}
+}
+
+func TestQueryItem(t *testing.T) {
+	t.Parallel()
+
+	col := ColumnRef{table: "users", column: "name"}
+	item := QueryItem{
+		Column:    col,
+		QueryType: FreeTextSearch,
+		Plaintext: "john",
+	}
+
+	if item.QueryType != FreeTextSearch {
+		t.Errorf("QueryType: got %q, want %q", item.QueryType, FreeTextSearch)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EncryptConfig structure tests
+// ---------------------------------------------------------------------------
+
+func TestEncryptConfigStructure(t *testing.T) {
+	t.Parallel()
+
+	castAs := CastAsText
+	config := EncryptConfig{
+		Version: 1,
+		Tables: Tables{
+			"users": Table{
+				"email": Column{
+					CastAs: &castAs,
+					Indexes: &Indexes{
+						OreIndex: &OreIndexOpts{},
+						UniqueIndex: &UniqueIndexOpts{
+							TokenFilters: []TokenFilter{{Kind: "downcase"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if config.Version != 1 {
+		t.Errorf("version: got %d, want 1", config.Version)
+	}
+
+	usersTable, exists := config.Tables["users"]
+	if !exists {
+		t.Fatal("missing users table")
+	}
+
+	emailColumn, exists := usersTable["email"]
+	if !exists {
+		t.Fatal("missing email column")
+	}
+
+	if *emailColumn.CastAs != CastAsText {
+		t.Errorf("CastAs: got %v, want %q", *emailColumn.CastAs, CastAsText)
+	}
+
+	if emailColumn.Indexes.OreIndex == nil {
+		t.Error("expected OreIndex")
+	}
+
+	if emailColumn.Indexes.UniqueIndex == nil {
+		t.Error("expected UniqueIndex")
+	}
+
+	if len(emailColumn.Indexes.UniqueIndex.TokenFilters) != 1 {
+		t.Errorf("token filters: got %d, want 1", len(emailColumn.Indexes.UniqueIndex.TokenFilters))
+	}
+
+	if emailColumn.Indexes.UniqueIndex.TokenFilters[0].Kind != "downcase" {
+		t.Errorf("token filter: got %q, want %q", emailColumn.Indexes.UniqueIndex.TokenFilters[0].Kind, "downcase")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LockContext tests
+// ---------------------------------------------------------------------------
+
+func TestLockContextJSON(t *testing.T) {
+	t.Parallel()
+
+	lc := LockContext{IdentityClaim: []string{"user:123", "org:456"}}
+
+	data, err := json.Marshal(lc)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded LockContext
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if len(decoded.IdentityClaim) != 2 {
+		t.Fatalf("IdentityClaim: got %d, want 2", len(decoded.IdentityClaim))
+	}
+	if decoded.IdentityClaim[0] != "user:123" || decoded.IdentityClaim[1] != "org:456" {
+		t.Errorf("IdentityClaim: got %v", decoded.IdentityClaim)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func castPtr(c CastAs) *CastAs {
+	return &c
 }

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -61,7 +61,7 @@ func TestCastAsConstants(t *testing.T) {
 		{"Number", CastAsNumber, "number"},
 		{"String", CastAsString, "string"},
 		{"Text", CastAsText, "text"},
-		{"Json", CastAsJson, "json"},
+		{"JSON", CastAsJSON, "json"},
 	}
 
 	for _, tc := range tests {
@@ -576,7 +576,7 @@ func TestErrorUnknownMessage(t *testing.T) {
 
 	err := newError("Test", "something completely unexpected happened")
 
-	// Should not match any sentinel.
+	// Should not match specific sentinels.
 	if errors.Is(err, ErrUnknownColumn) {
 		t.Error("should not match ErrUnknownColumn")
 	}
@@ -584,13 +584,17 @@ func TestErrorUnknownMessage(t *testing.T) {
 		t.Error("should not match ErrMissingIndex")
 	}
 
-	// The wrapped Err should be nil.
+	// Should match the generic FFI sentinel.
+	if !errors.Is(err, ErrFFI) {
+		t.Error("should match ErrFFI for unclassified FFI errors")
+	}
+
 	var protectErr *Error
 	if !errors.As(err, &protectErr) {
 		t.Fatal("errors.As should match *Error")
 	}
-	if protectErr.Err != nil {
-		t.Errorf("Err: got %v, want nil", protectErr.Err)
+	if protectErr.Err != ErrFFI {
+		t.Errorf("Err: got %v, want ErrFFI", protectErr.Err)
 	}
 }
 

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -1,6 +1,8 @@
 package protect
 
 import (
+	"encoding/json"
+	"errors"
 	"testing"
 )
 
@@ -14,6 +16,25 @@ func TestIdentifier(t *testing.T) {
 
 	if ident.Column != "email" {
 		t.Errorf("Expected column 'email', got '%s'", ident.Column)
+	}
+}
+
+// TestIdentifierJSON tests JSON serialization of Identifier
+func TestIdentifierJSON(t *testing.T) {
+	ident := NewIdentifier("users", "email")
+
+	data, err := json.Marshal(ident)
+	if err != nil {
+		t.Fatalf("Failed to marshal Identifier: %v", err)
+	}
+
+	var decoded Identifier
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Failed to unmarshal Identifier: %v", err)
+	}
+
+	if decoded.Table != "users" || decoded.Column != "email" {
+		t.Errorf("Round-trip failed: got table=%q column=%q", decoded.Table, decoded.Column)
 	}
 }
 
@@ -77,24 +98,25 @@ func TestEncryptConfigStructure(t *testing.T) {
 // TestCastAsConstants tests the CastAs constants
 func TestCastAsConstants(t *testing.T) {
 	tests := []struct {
+		name     string
 		constant CastAs
 		expected string
 	}{
-		{CastAsBigInt, "big_int"},
-		{CastAsBoolean, "boolean"},
-		{CastAsDate, "date"},
-		{CastAsReal, "real"},
-		{CastAsDouble, "double"},
-		{CastAsInt, "int"},
-		{CastAsSmallInt, "small_int"},
-		{CastAsText, "text"},
-		{CastAsJsonB, "jsonb"},
+		{"BigInt", CastAsBigInt, "bigint"},
+		{"Boolean", CastAsBoolean, "boolean"},
+		{"Date", CastAsDate, "date"},
+		{"Number", CastAsNumber, "number"},
+		{"String", CastAsString, "string"},
+		{"Text", CastAsText, "text"},
+		{"Json", CastAsJson, "json"},
 	}
 
-	for _, test := range tests {
-		if string(test.constant) != test.expected {
-			t.Errorf("Expected %s, got %s", test.expected, string(test.constant))
-		}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if string(tc.constant) != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, string(tc.constant))
+			}
+		})
 	}
 }
 
@@ -112,7 +134,7 @@ func TestEncryptOptions(t *testing.T) {
 	}
 
 	if opts.Plaintext != "test@example.com" {
-		t.Errorf("Expected plaintext 'test@example.com', got '%s'", opts.Plaintext)
+		t.Errorf("Expected plaintext 'test@example.com', got '%v'", opts.Plaintext)
 	}
 
 	if opts.Column != "email" {
@@ -136,6 +158,47 @@ func TestEncryptOptions(t *testing.T) {
 	}
 }
 
+// TestEncryptOptionsMultiType tests that EncryptOptions accepts multiple plaintext types
+func TestEncryptOptionsMultiType(t *testing.T) {
+	tests := []struct {
+		name      string
+		plaintext interface{}
+	}{
+		{"string", "hello world"},
+		{"number_int", 42},
+		{"number_float", 3.14},
+		{"boolean_true", true},
+		{"boolean_false", false},
+		{"json_object", map[string]interface{}{"key": "value"}},
+		{"json_array", []interface{}{"a", "b", "c"}},
+		{"nil", nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := EncryptOptions{
+				Plaintext: tc.plaintext,
+				Column:    "data",
+				Table:     "test",
+			}
+
+			data, err := json.Marshal(opts)
+			if err != nil {
+				t.Fatalf("Failed to marshal EncryptOptions with %s plaintext: %v", tc.name, err)
+			}
+
+			var decoded map[string]interface{}
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("Failed to unmarshal EncryptOptions: %v", err)
+			}
+
+			if _, exists := decoded["plaintext"]; !exists && tc.plaintext != nil {
+				t.Error("Expected plaintext field in JSON output")
+			}
+		})
+	}
+}
+
 // TestBulkEncryptOptions tests the bulk encrypt options structure
 func TestBulkEncryptOptions(t *testing.T) {
 	opts := EncryptBulkOptions{
@@ -146,8 +209,8 @@ func TestBulkEncryptOptions(t *testing.T) {
 				Table:     "users",
 			},
 			{
-				Plaintext: "bob@example.com",
-				Column:    "email",
+				Plaintext: 42,
+				Column:    "age",
 				Table:     "users",
 			},
 		},
@@ -158,50 +221,185 @@ func TestBulkEncryptOptions(t *testing.T) {
 	}
 
 	if opts.Plaintexts[0].Plaintext != "alice@example.com" {
-		t.Errorf("Expected 'alice@example.com', got '%s'", opts.Plaintexts[0].Plaintext)
+		t.Errorf("Expected 'alice@example.com', got '%v'", opts.Plaintexts[0].Plaintext)
 	}
 
-	if opts.Plaintexts[1].Plaintext != "bob@example.com" {
-		t.Errorf("Expected 'bob@example.com', got '%s'", opts.Plaintexts[1].Plaintext)
+	if opts.Plaintexts[1].Plaintext != 42 {
+		t.Errorf("Expected 42, got '%v'", opts.Plaintexts[1].Plaintext)
 	}
 }
 
-// TestDecryptResult tests the decrypt result structure
+// TestDecryptOptions tests the decrypt options structure with Encrypted ciphertext
+func TestDecryptOptions(t *testing.T) {
+	ct := "encrypted-data"
+	encrypted := &Encrypted{
+		Identifier: NewIdentifier("users", "email"),
+		Version:    1,
+		Ciphertext: &ct,
+	}
+
+	opts := DecryptOptions{
+		Ciphertext: encrypted,
+	}
+
+	if opts.Ciphertext == nil {
+		t.Fatal("Expected Ciphertext to be set")
+	}
+
+	if opts.Ciphertext.Version != 1 {
+		t.Errorf("Expected version 1, got %d", opts.Ciphertext.Version)
+	}
+
+	if *opts.Ciphertext.Ciphertext != "encrypted-data" {
+		t.Errorf("Expected 'encrypted-data', got '%s'", *opts.Ciphertext.Ciphertext)
+	}
+}
+
+// TestDecryptOptionsJSON tests JSON serialization of DecryptOptions
+func TestDecryptOptionsJSON(t *testing.T) {
+	ct := "encrypted-data"
+	encrypted := &Encrypted{
+		Identifier: NewIdentifier("users", "email"),
+		Version:    1,
+		Ciphertext: &ct,
+	}
+
+	opts := DecryptOptions{
+		Ciphertext: encrypted,
+	}
+
+	data, err := json.Marshal(opts)
+	if err != nil {
+		t.Fatalf("Failed to marshal DecryptOptions: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Failed to unmarshal DecryptOptions: %v", err)
+	}
+
+	ciphertext, ok := decoded["ciphertext"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected ciphertext to be an object")
+	}
+
+	if ciphertext["c"] != "encrypted-data" {
+		t.Errorf("Expected ciphertext.c to be 'encrypted-data', got '%v'", ciphertext["c"])
+	}
+}
+
+// TestBulkDecryptPayload tests the bulk decrypt payload with Encrypted ciphertext
+func TestBulkDecryptPayload(t *testing.T) {
+	ct := "encrypted-data"
+	encrypted := &Encrypted{
+		Identifier: NewIdentifier("users", "email"),
+		Version:    1,
+		Ciphertext: &ct,
+	}
+
+	payload := BulkDecryptPayload{
+		Ciphertext: encrypted,
+	}
+
+	if payload.Ciphertext == nil {
+		t.Fatal("Expected Ciphertext to be set")
+	}
+
+	if *payload.Ciphertext.Ciphertext != "encrypted-data" {
+		t.Errorf("Expected 'encrypted-data', got '%s'", *payload.Ciphertext.Ciphertext)
+	}
+}
+
+// TestDecryptResult tests the decrypt result structure with interface{} data
 func TestDecryptResult(t *testing.T) {
-	// Test successful result
-	data := "decrypted data"
-	successResult := DecryptResult{
-		Data: &data,
+	t.Run("string data", func(t *testing.T) {
+		result := DecryptResult{
+			Data: "decrypted data",
+		}
+
+		if result.Data == nil {
+			t.Error("Expected data to be set")
+		}
+
+		if result.Data != "decrypted data" {
+			t.Errorf("Expected 'decrypted data', got '%v'", result.Data)
+		}
+
+		if result.Error != nil {
+			t.Error("Expected error to be nil for successful result")
+		}
+	})
+
+	t.Run("numeric data", func(t *testing.T) {
+		result := DecryptResult{
+			Data: 42.0,
+		}
+
+		if result.Data != 42.0 {
+			t.Errorf("Expected 42.0, got '%v'", result.Data)
+		}
+	})
+
+	t.Run("boolean data", func(t *testing.T) {
+		result := DecryptResult{
+			Data: true,
+		}
+
+		if result.Data != true {
+			t.Errorf("Expected true, got '%v'", result.Data)
+		}
+	})
+
+	t.Run("nil data", func(t *testing.T) {
+		result := DecryptResult{
+			Data: nil,
+		}
+
+		if result.Data != nil {
+			t.Error("Expected data to be nil")
+		}
+	})
+
+	t.Run("error result", func(t *testing.T) {
+		errorMsg := "decryption failed"
+		result := DecryptResult{
+			Error: &errorMsg,
+		}
+
+		if result.Error == nil {
+			t.Error("Expected error to be set")
+		}
+
+		if *result.Error != "decryption failed" {
+			t.Errorf("Expected 'decryption failed', got '%s'", *result.Error)
+		}
+
+		if result.Data != nil {
+			t.Error("Expected data to be nil for error result")
+		}
+	})
+}
+
+// TestDecryptResultJSON tests JSON round-trip of DecryptResult with multi-type data
+func TestDecryptResultJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{"string", `{"data":"hello"}`},
+		{"number", `{"data":42}`},
+		{"boolean", `{"data":true}`},
+		{"null", `{"data":null}`},
+		{"error", `{"error":"failed"}`},
 	}
 
-	if successResult.Data == nil {
-		t.Error("Expected data to be set")
-	}
-
-	if *successResult.Data != "decrypted data" {
-		t.Errorf("Expected 'decrypted data', got '%s'", *successResult.Data)
-	}
-
-	if successResult.Error != nil {
-		t.Error("Expected error to be nil for successful result")
-	}
-
-	// Test error result
-	errorMsg := "decryption failed"
-	errorResult := DecryptResult{
-		Error: &errorMsg,
-	}
-
-	if errorResult.Error == nil {
-		t.Error("Expected error to be set")
-	}
-
-	if *errorResult.Error != "decryption failed" {
-		t.Errorf("Expected 'decryption failed', got '%s'", *errorResult.Error)
-	}
-
-	if errorResult.Data != nil {
-		t.Error("Expected data to be nil for error result")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var result DecryptResult
+			if err := json.Unmarshal([]byte(tc.json), &result); err != nil {
+				t.Fatalf("Failed to unmarshal: %v", err)
+			}
+		})
 	}
 }
 
@@ -289,5 +487,525 @@ func TestMatchIndexOpts(t *testing.T) {
 
 	if matchOpts.IncludeOriginal == nil || *matchOpts.IncludeOriginal != true {
 		t.Errorf("Expected IncludeOriginal to be true, got %v", matchOpts.IncludeOriginal)
+	}
+}
+
+// TestSteVecIndexOpts tests the SteVec index options with new fields
+func TestSteVecIndexOpts(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		opts := SteVecIndexOpts{
+			Prefix: "users",
+		}
+
+		if opts.Prefix != "users" {
+			t.Errorf("Expected prefix 'users', got '%s'", opts.Prefix)
+		}
+
+		if opts.TermFilters != nil {
+			t.Error("Expected TermFilters to be nil")
+		}
+
+		if opts.ArrayIndexMode != nil {
+			t.Error("Expected ArrayIndexMode to be nil")
+		}
+	})
+
+	t.Run("with term filters and array index mode", func(t *testing.T) {
+		arrayMode := "flatten"
+		opts := SteVecIndexOpts{
+			Prefix: "products",
+			TermFilters: []TokenFilter{
+				{Kind: "downcase"},
+				{Kind: "trim"},
+			},
+			ArrayIndexMode: &arrayMode,
+		}
+
+		if opts.Prefix != "products" {
+			t.Errorf("Expected prefix 'products', got '%s'", opts.Prefix)
+		}
+
+		if len(opts.TermFilters) != 2 {
+			t.Errorf("Expected 2 term filters, got %d", len(opts.TermFilters))
+		}
+
+		if opts.TermFilters[0].Kind != "downcase" {
+			t.Errorf("Expected 'downcase', got '%s'", opts.TermFilters[0].Kind)
+		}
+
+		if opts.ArrayIndexMode == nil || *opts.ArrayIndexMode != "flatten" {
+			t.Errorf("Expected ArrayIndexMode 'flatten', got %v", opts.ArrayIndexMode)
+		}
+	})
+
+	t.Run("json round-trip", func(t *testing.T) {
+		arrayMode := "flatten"
+		opts := SteVecIndexOpts{
+			Prefix: "test",
+			TermFilters: []TokenFilter{
+				{Kind: "downcase"},
+			},
+			ArrayIndexMode: &arrayMode,
+		}
+
+		data, err := json.Marshal(opts)
+		if err != nil {
+			t.Fatalf("Failed to marshal: %v", err)
+		}
+
+		var decoded SteVecIndexOpts
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Failed to unmarshal: %v", err)
+		}
+
+		if decoded.Prefix != "test" {
+			t.Errorf("Expected prefix 'test', got '%s'", decoded.Prefix)
+		}
+
+		if len(decoded.TermFilters) != 1 {
+			t.Errorf("Expected 1 term filter, got %d", len(decoded.TermFilters))
+		}
+
+		if decoded.ArrayIndexMode == nil || *decoded.ArrayIndexMode != "flatten" {
+			t.Errorf("Expected ArrayIndexMode 'flatten', got %v", decoded.ArrayIndexMode)
+		}
+	})
+}
+
+// TestEncryptedStruct tests the Encrypted struct without Kind field
+func TestEncryptedStruct(t *testing.T) {
+	ct := "ciphertext-value"
+	ore := []string{"ore1", "ore2"}
+	match := []uint16{1, 2, 3}
+	unique := "unique-hash"
+
+	encrypted := Encrypted{
+		Identifier:  NewIdentifier("users", "email"),
+		Version:     1,
+		Ciphertext:  &ct,
+		OreIndex:    &ore,
+		MatchIndex:  &match,
+		UniqueIndex: &unique,
+	}
+
+	if encrypted.Identifier.Table != "users" {
+		t.Errorf("Expected table 'users', got '%s'", encrypted.Identifier.Table)
+	}
+
+	if encrypted.Version != 1 {
+		t.Errorf("Expected version 1, got %d", encrypted.Version)
+	}
+
+	if *encrypted.Ciphertext != "ciphertext-value" {
+		t.Errorf("Expected 'ciphertext-value', got '%s'", *encrypted.Ciphertext)
+	}
+}
+
+// TestEncryptedJSON tests JSON serialization of Encrypted (no Kind field)
+func TestEncryptedJSON(t *testing.T) {
+	ct := "ciphertext-value"
+	encrypted := Encrypted{
+		Identifier: NewIdentifier("users", "email"),
+		Version:    1,
+		Ciphertext: &ct,
+	}
+
+	data, err := json.Marshal(encrypted)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	// Verify Kind field is not present
+	if _, exists := decoded["k"]; exists {
+		t.Error("Expected 'k' (Kind) field to not be present in JSON output")
+	}
+
+	// Verify expected fields
+	if decoded["c"] != "ciphertext-value" {
+		t.Errorf("Expected c='ciphertext-value', got '%v'", decoded["c"])
+	}
+
+	// Version should be present
+	if decoded["v"] == nil {
+		t.Error("Expected 'v' field to be present")
+	}
+}
+
+// TestKeysetConfig tests the KeysetConfig structure
+func TestKeysetConfig(t *testing.T) {
+	t.Run("with name", func(t *testing.T) {
+		name := "my-keyset"
+		config := KeysetConfig{
+			Name: &name,
+		}
+
+		if config.Name == nil || *config.Name != "my-keyset" {
+			t.Errorf("Expected name 'my-keyset', got %v", config.Name)
+		}
+
+		if config.ID != nil {
+			t.Error("Expected ID to be nil")
+		}
+	})
+
+	t.Run("with id", func(t *testing.T) {
+		id := "keyset-123"
+		config := KeysetConfig{
+			ID: &id,
+		}
+
+		if config.ID == nil || *config.ID != "keyset-123" {
+			t.Errorf("Expected id 'keyset-123', got %v", config.ID)
+		}
+
+		if config.Name != nil {
+			t.Error("Expected Name to be nil")
+		}
+	})
+
+	t.Run("json omitempty", func(t *testing.T) {
+		name := "test"
+		config := KeysetConfig{
+			Name: &name,
+		}
+
+		data, err := json.Marshal(config)
+		if err != nil {
+			t.Fatalf("Failed to marshal: %v", err)
+		}
+
+		var decoded map[string]interface{}
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Failed to unmarshal: %v", err)
+		}
+
+		if _, exists := decoded["id"]; exists {
+			t.Error("Expected 'id' to be omitted when nil")
+		}
+	})
+}
+
+// TestClientOptsWithKeyset tests ClientOpts includes Keyset field
+func TestClientOptsWithKeyset(t *testing.T) {
+	keysetName := "my-keyset"
+	opts := ClientOpts{
+		Keyset: &KeysetConfig{
+			Name: &keysetName,
+		},
+	}
+
+	data, err := json.Marshal(opts)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	keyset, ok := decoded["keyset"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected keyset to be an object")
+	}
+
+	if keyset["name"] != "my-keyset" {
+		t.Errorf("Expected keyset.name='my-keyset', got '%v'", keyset["name"])
+	}
+}
+
+// TestQueryOpConstants tests the QueryOp constants
+func TestQueryOpConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant QueryOp
+		expected string
+	}{
+		{"Default", QueryOpDefault, "default"},
+		{"SteVecSelector", QueryOpSteVecSelector, "ste_vec_selector"},
+		{"SteVecTerm", QueryOpSteVecTerm, "ste_vec_term"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if string(tc.constant) != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, string(tc.constant))
+			}
+		})
+	}
+}
+
+// TestIndexTypeConstants tests the IndexType constants
+func TestIndexTypeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant IndexType
+		expected string
+	}{
+		{"Ore", IndexTypeOre, "ore"},
+		{"Unique", IndexTypeUnique, "unique"},
+		{"Match", IndexTypeMatch, "match"},
+		{"SteVec", IndexTypeSteVec, "ste_vec"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if string(tc.constant) != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, string(tc.constant))
+			}
+		})
+	}
+}
+
+// TestEncryptQueryOptions tests the EncryptQueryOptions structure
+func TestEncryptQueryOptions(t *testing.T) {
+	opts := EncryptQueryOptions{
+		Plaintext: "search-term",
+		Column:    "email",
+		Table:     "users",
+		IndexType: IndexTypeMatch,
+		QueryOp:   QueryOpDefault,
+	}
+
+	if opts.Plaintext != "search-term" {
+		t.Errorf("Expected plaintext 'search-term', got '%v'", opts.Plaintext)
+	}
+
+	if opts.IndexType != IndexTypeMatch {
+		t.Errorf("Expected IndexTypeMatch, got '%s'", opts.IndexType)
+	}
+
+	if opts.QueryOp != QueryOpDefault {
+		t.Errorf("Expected QueryOpDefault, got '%s'", opts.QueryOp)
+	}
+}
+
+// TestEncryptQueryOptionsJSON tests JSON serialization of EncryptQueryOptions
+func TestEncryptQueryOptionsJSON(t *testing.T) {
+	opts := EncryptQueryOptions{
+		Plaintext: "test",
+		Column:    "email",
+		Table:     "users",
+		IndexType: IndexTypeOre,
+	}
+
+	data, err := json.Marshal(opts)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	if decoded["indexType"] != "ore" {
+		t.Errorf("Expected indexType='ore', got '%v'", decoded["indexType"])
+	}
+
+	// queryOp should be omitted when zero value
+	if _, exists := decoded["queryOp"]; exists {
+		t.Error("Expected queryOp to be omitted when empty")
+	}
+}
+
+// TestQueryPayload tests the QueryPayload structure
+func TestQueryPayload(t *testing.T) {
+	payload := QueryPayload{
+		Plaintext: "search",
+		Column:    "name",
+		Table:     "users",
+		IndexType: IndexTypeSteVec,
+		QueryOp:   QueryOpSteVecTerm,
+	}
+
+	if payload.IndexType != IndexTypeSteVec {
+		t.Errorf("Expected IndexTypeSteVec, got '%s'", payload.IndexType)
+	}
+
+	if payload.QueryOp != QueryOpSteVecTerm {
+		t.Errorf("Expected QueryOpSteVecTerm, got '%s'", payload.QueryOp)
+	}
+}
+
+// TestEncryptQueryBulkOptions tests the EncryptQueryBulkOptions structure
+func TestEncryptQueryBulkOptions(t *testing.T) {
+	opts := EncryptQueryBulkOptions{
+		Queries: []QueryPayload{
+			{
+				Plaintext: "term1",
+				Column:    "email",
+				Table:     "users",
+				IndexType: IndexTypeMatch,
+			},
+			{
+				Plaintext: "term2",
+				Column:    "name",
+				Table:     "users",
+				IndexType: IndexTypeOre,
+			},
+		},
+	}
+
+	if len(opts.Queries) != 2 {
+		t.Errorf("Expected 2 queries, got %d", len(opts.Queries))
+	}
+
+	if opts.Queries[0].Plaintext != "term1" {
+		t.Errorf("Expected 'term1', got '%v'", opts.Queries[0].Plaintext)
+	}
+
+	if opts.Queries[1].IndexType != IndexTypeOre {
+		t.Errorf("Expected IndexTypeOre, got '%s'", opts.Queries[1].IndexType)
+	}
+}
+
+// TestEncryptionError tests the EncryptionError type
+func TestEncryptionError(t *testing.T) {
+	err := &EncryptionError{
+		Code:    ErrUnknownColumn,
+		Message: "column 'foo' not found in Encrypt config",
+	}
+
+	if err.Error() != "column 'foo' not found in Encrypt config" {
+		t.Errorf("Expected error message, got '%s'", err.Error())
+	}
+
+	if err.Code != ErrUnknownColumn {
+		t.Errorf("Expected ErrUnknownColumn, got '%s'", err.Code)
+	}
+
+	// Test that it implements the error interface
+	var e error = err
+	if e == nil {
+		t.Error("Expected non-nil error")
+	}
+}
+
+// TestEncryptionErrorUnwrap tests that EncryptionError can be matched with errors.As
+func TestEncryptionErrorUnwrap(t *testing.T) {
+	err := newEncryptionError("column 'foo' not found in Encrypt config")
+
+	var encErr *EncryptionError
+	if !errors.As(err, &encErr) {
+		t.Error("Expected errors.As to match EncryptionError")
+	}
+
+	if encErr.Code != ErrUnknownColumn {
+		t.Errorf("Expected ErrUnknownColumn, got '%s'", encErr.Code)
+	}
+}
+
+// TestInferErrorCode tests the error code inference from messages
+func TestInferErrorCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		expected ErrorCode
+	}{
+		{
+			"invariant violation",
+			"invariant violation: something went wrong",
+			ErrInvariantViolation,
+		},
+		{
+			"unknown query op",
+			"Unknown query operation 'foo'",
+			ErrUnknownQueryOp,
+		},
+		{
+			"unknown column",
+			"column 'bar' not found in Encrypt config",
+			ErrUnknownColumn,
+		},
+		{
+			"missing index",
+			"column 'baz' does not have a match index",
+			ErrMissingIndex,
+		},
+		{
+			"invalid query input",
+			"Invalid query input: expected string",
+			ErrInvalidQueryInput,
+		},
+		{
+			"invalid json path",
+			"Invalid JSON path: $.foo.bar",
+			ErrInvalidJsonPath,
+		},
+		{
+			"ste_vec requires json cast_as",
+			"ste_vec index requires cast_as to be json",
+			ErrSteVecRequiresJsonCastAs,
+		},
+		{
+			"unknown error",
+			"something completely unexpected happened",
+			ErrUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code := inferErrorCode(tc.message)
+			if code != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, code)
+			}
+		})
+	}
+}
+
+// TestNewEncryptionError tests the newEncryptionError constructor
+func TestNewEncryptionError(t *testing.T) {
+	err := newEncryptionError("column 'email' not found in Encrypt config")
+
+	if err.Code != ErrUnknownColumn {
+		t.Errorf("Expected ErrUnknownColumn, got '%s'", err.Code)
+	}
+
+	if err.Message != "column 'email' not found in Encrypt config" {
+		t.Errorf("Unexpected message: '%s'", err.Message)
+	}
+}
+
+// TestPlaintextPayloadMultiType tests PlaintextPayload with different types
+func TestPlaintextPayloadMultiType(t *testing.T) {
+	tests := []struct {
+		name      string
+		plaintext interface{}
+	}{
+		{"string", "hello"},
+		{"number", 42},
+		{"boolean", true},
+		{"json", map[string]interface{}{"nested": "value"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := PlaintextPayload{
+				Plaintext: tc.plaintext,
+				Column:    "data",
+				Table:     "test",
+			}
+
+			data, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("Failed to marshal: %v", err)
+			}
+
+			var decoded map[string]interface{}
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("Failed to unmarshal: %v", err)
+			}
+
+			if decoded["plaintext"] == nil {
+				t.Error("Expected plaintext to be present")
+			}
+		})
 	}
 }

--- a/pkg/protect/schema.go
+++ b/pkg/protect/schema.go
@@ -7,27 +7,42 @@ import (
 	"strings"
 )
 
-// TableDef holds a parsed table schema ready for building an EncryptConfig.
+// TableDef holds a parsed table schema. It is the primary reference for
+// table and column identification throughout the API. Create one with
+// TableSchema (from struct tags) or NewSchema (programmatic builder).
 type TableDef struct {
-	Name    string
-	Columns map[string]Column
+	name    string
+	columns map[string]Column
 }
 
-// TableSchema creates a table schema definition from a struct type.
-// It parses the `cs` struct tags to determine column names, cast types, and indexes.
-// The model parameter can be a struct value or a pointer to a struct.
-// TableSchema panics if model is not a struct or pointer to struct, since this
-// indicates a programming error that should be caught during initialization.
-func TableSchema(tableName string, model interface{}) *TableDef {
+// Name returns the table name.
+func (td *TableDef) Name() string {
+	return td.name
+}
+
+// Column returns a ColumnRef for the named column in this table.
+// It panics if the column name is not defined in the schema, since
+// this indicates a programming error that should be caught at init time.
+func (td *TableDef) Column(name string) ColumnRef {
+	if _, ok := td.columns[name]; !ok {
+		panic(fmt.Sprintf("protect: column %q not found in table %q", name, td.name))
+	}
+	return ColumnRef{table: td.name, column: name}
+}
+
+// TableSchema creates a table schema definition by parsing `cs` struct tags
+// on the given model. The model parameter must be a struct value or pointer
+// to a struct.
+func TableSchema(tableName string, model any) (*TableDef, error) {
 	typ := reflect.TypeOf(model)
 	if typ == nil {
-		panic("protect.TableSchema: model must not be nil")
+		return nil, fmt.Errorf("protect.TableSchema: model must not be nil")
 	}
 	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()
 	}
 	if typ.Kind() != reflect.Struct {
-		panic(fmt.Sprintf("protect.TableSchema: model must be a struct, got %s", typ.Kind()))
+		return nil, fmt.Errorf("protect.TableSchema: model must be a struct, got %s", typ.Kind())
 	}
 
 	columns := make(map[string]Column)
@@ -54,26 +69,153 @@ func TableSchema(tableName string, model interface{}) *TableDef {
 	}
 
 	return &TableDef{
-		Name:    tableName,
-		Columns: columns,
+		name:    tableName,
+		columns: columns,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Programmatic schema builder
+// ---------------------------------------------------------------------------
+
+// SchemaBuilder constructs a TableDef programmatically.
+type SchemaBuilder struct {
+	name    string
+	columns map[string]Column
+}
+
+// ColumnBuilder configures a single column within a SchemaBuilder.
+type ColumnBuilder struct {
+	parent  *SchemaBuilder
+	name    string
+	castAs  CastAs
+	indexes Indexes
+}
+
+// MatchOption configures optional parameters for a match (free-text search) index.
+type MatchOption func(*MatchIndexOpts)
+
+// WithK sets the number of hash functions for the bloom filter.
+func WithK(k int) MatchOption {
+	return func(o *MatchIndexOpts) { o.K = &k }
+}
+
+// WithM sets the size of the bloom filter in bits.
+func WithM(m int) MatchOption {
+	return func(o *MatchIndexOpts) { o.M = &m }
+}
+
+// WithTokenizer sets the tokenizer kind (e.g., "ngram", "standard").
+func WithTokenizer(kind string) MatchOption {
+	return func(o *MatchIndexOpts) {
+		if o.Tokenizer == nil {
+			o.Tokenizer = &Tokenizer{}
+		}
+		o.Tokenizer.Kind = kind
 	}
 }
 
-// BuildEncryptConfig creates an EncryptConfig from one or more table schema definitions.
-func BuildEncryptConfig(tables ...*TableDef) EncryptConfig {
-	tbls := make(Tables, len(tables))
-	for _, td := range tables {
-		tbl := make(Table, len(td.Columns))
-		for colName, col := range td.Columns {
-			tbl[colName] = col
+// WithTokenLength sets the token length for the ngram tokenizer.
+func WithTokenLength(n int) MatchOption {
+	return func(o *MatchIndexOpts) {
+		if o.Tokenizer == nil {
+			o.Tokenizer = &Tokenizer{}
 		}
-		tbls[td.Name] = tbl
-	}
-	return EncryptConfig{
-		Version: 1,
-		Tables:  tbls,
+		o.Tokenizer.TokenLength = &n
 	}
 }
+
+// WithIncludeOriginal controls whether the original value is included in the index.
+func WithIncludeOriginal(include bool) MatchOption {
+	return func(o *MatchIndexOpts) { o.IncludeOriginal = &include }
+}
+
+// NewSchema starts building a table schema with the given name.
+func NewSchema(tableName string) *SchemaBuilder {
+	return &SchemaBuilder{
+		name:    tableName,
+		columns: make(map[string]Column),
+	}
+}
+
+// Column begins configuring a new encrypted column.
+func (b *SchemaBuilder) Column(name string, castAs CastAs) *ColumnBuilder {
+	return &ColumnBuilder{
+		parent: b,
+		name:   name,
+		castAs: castAs,
+	}
+}
+
+// Equality adds a unique (HMAC) index to the column, with optional token filters.
+func (cb *ColumnBuilder) Equality(filters ...TokenFilter) *ColumnBuilder {
+	cb.indexes.UniqueIndex = &UniqueIndexOpts{TokenFilters: filters}
+	return cb
+}
+
+// FreeTextSearch adds a match (bloom filter) index to the column.
+func (cb *ColumnBuilder) FreeTextSearch(optFns ...MatchOption) *ColumnBuilder {
+	opts := defaultMatchOpts()
+	for _, fn := range optFns {
+		fn(opts)
+	}
+	cb.indexes.MatchIndex = opts
+	return cb
+}
+
+// OrderAndRange adds an ORE index to the column for range and ordering queries.
+func (cb *ColumnBuilder) OrderAndRange() *ColumnBuilder {
+	cb.indexes.OreIndex = &OreIndexOpts{}
+	return cb
+}
+
+// SearchableJSON adds an ste_vec index and sets the cast type to JSON.
+func (cb *ColumnBuilder) SearchableJSON(prefix string) *ColumnBuilder {
+	cb.castAs = CastAsJson
+	cb.indexes.SteVecIndex = &SteVecIndexOpts{Prefix: prefix}
+	return cb
+}
+
+// Done finalizes the column and returns the parent SchemaBuilder.
+func (cb *ColumnBuilder) Done() *SchemaBuilder {
+	ca := cb.castAs
+	col := Column{
+		CastAs:  &ca,
+		Indexes: &cb.indexes,
+	}
+	cb.parent.columns[cb.name] = col
+	return cb.parent
+}
+
+// Build creates the TableDef from the builder configuration.
+func (b *SchemaBuilder) Build() *TableDef {
+	return &TableDef{
+		name:    b.name,
+		columns: b.columns,
+	}
+}
+
+// defaultMatchOpts returns the default MatchIndexOpts matching the TypeScript SDK.
+func defaultMatchOpts() *MatchIndexOpts {
+	tokenLength := 3
+	k := 6
+	m := 2048
+	includeOriginal := true
+	return &MatchIndexOpts{
+		Tokenizer: &Tokenizer{
+			Kind:        "ngram",
+			TokenLength: &tokenLength,
+		},
+		TokenFilters:    []TokenFilter{{Kind: "downcase"}},
+		K:               &k,
+		M:               &m,
+		IncludeOriginal: &includeOriginal,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tag parsing (internal, unchanged logic)
+// ---------------------------------------------------------------------------
 
 // parseCSTag splits a cs struct tag value into the column name and remaining directives.
 // For example, "email,unique(downcase),match" returns ("email", ["unique(downcase)", "match"]).

--- a/pkg/protect/schema.go
+++ b/pkg/protect/schema.go
@@ -20,14 +20,26 @@ func (td *TableDef) Name() string {
 	return td.name
 }
 
-// Column returns a ColumnRef for the named column in this table.
+// Column returns a [ColumnRef] for the named column in this table.
 // It panics if the column name is not defined in the schema, since
 // this indicates a programming error that should be caught at init time.
+//
+// For a non-panicking alternative, use [TableDef.ColumnOK].
 func (td *TableDef) Column(name string) ColumnRef {
 	if _, ok := td.columns[name]; !ok {
 		panic(fmt.Sprintf("protect: column %q not found in table %q", name, td.name))
 	}
 	return ColumnRef{table: td.name, column: name}
+}
+
+// ColumnOK returns a [ColumnRef] for the named column and a boolean indicating
+// whether the column exists in the schema. Unlike [TableDef.Column], it does
+// not panic on unknown columns.
+func (td *TableDef) ColumnOK(name string) (ColumnRef, bool) {
+	if _, ok := td.columns[name]; !ok {
+		return ColumnRef{}, false
+	}
+	return ColumnRef{table: td.name, column: name}, true
 }
 
 // TableSchema creates a table schema definition by parsing `cs` struct tags
@@ -171,7 +183,7 @@ func (cb *ColumnBuilder) OrderAndRange() *ColumnBuilder {
 
 // SearchableJSON adds an ste_vec index and sets the cast type to JSON.
 func (cb *ColumnBuilder) SearchableJSON(prefix string) *ColumnBuilder {
-	cb.castAs = CastAsJson
+	cb.castAs = CastAsJSON
 	cb.indexes.SteVecIndex = &SteVecIndexOpts{Prefix: prefix}
 	return cb
 }
@@ -285,7 +297,7 @@ func parseColumn(directives []string, fieldType reflect.Type) Column {
 	// Determine cast type.
 	if castAs == nil {
 		if autoJson {
-			ca := CastAsJson
+			ca := CastAsJSON
 			castAs = &ca
 		} else {
 			ca := inferCastAs(fieldType)
@@ -417,7 +429,7 @@ func inferCastAs(fieldType reflect.Type) CastAs {
 		return CastAsBoolean
 	default:
 		// Maps, structs, interfaces, slices, arrays, etc.
-		return CastAsJson
+		return CastAsJSON
 	}
 }
 

--- a/pkg/protect/schema.go
+++ b/pkg/protect/schema.go
@@ -1,0 +1,323 @@
+package protect
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// TableDef holds a parsed table schema ready for building an EncryptConfig.
+type TableDef struct {
+	Name    string
+	Columns map[string]Column
+}
+
+// TableSchema creates a table schema definition from a struct type.
+// It parses the `cs` struct tags to determine column names, cast types, and indexes.
+// The model parameter can be a struct value or a pointer to a struct.
+// TableSchema panics if model is not a struct or pointer to struct, since this
+// indicates a programming error that should be caught during initialization.
+func TableSchema(tableName string, model interface{}) *TableDef {
+	typ := reflect.TypeOf(model)
+	if typ == nil {
+		panic("protect.TableSchema: model must not be nil")
+	}
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("protect.TableSchema: model must be a struct, got %s", typ.Kind()))
+	}
+
+	columns := make(map[string]Column)
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+
+		// Skip unexported fields.
+		if !field.IsExported() {
+			continue
+		}
+
+		csTag, hasCS := field.Tag.Lookup("cs")
+		if !hasCS || csTag == "" || csTag == "-" {
+			continue
+		}
+
+		columnName, directives := parseCSTag(csTag)
+		if columnName == "" || columnName == "-" {
+			continue
+		}
+
+		columns[columnName] = parseColumn(directives, field.Type)
+	}
+
+	return &TableDef{
+		Name:    tableName,
+		Columns: columns,
+	}
+}
+
+// BuildEncryptConfig creates an EncryptConfig from one or more table schema definitions.
+func BuildEncryptConfig(tables ...*TableDef) EncryptConfig {
+	tbls := make(Tables, len(tables))
+	for _, td := range tables {
+		tbl := make(Table, len(td.Columns))
+		for colName, col := range td.Columns {
+			tbl[colName] = col
+		}
+		tbls[td.Name] = tbl
+	}
+	return EncryptConfig{
+		Version: 1,
+		Tables:  tbls,
+	}
+}
+
+// parseCSTag splits a cs struct tag value into the column name and remaining directives.
+// For example, "email,unique(downcase),match" returns ("email", ["unique(downcase)", "match"]).
+func parseCSTag(tag string) (columnName string, directives []string) {
+	parts := splitTagParts(tag)
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return parts[0], parts[1:]
+}
+
+// splitTagParts splits a cs tag value by commas, respecting parenthesized groups.
+// For example, "email,match(k=8,m=1024),ore" splits into ["email", "match(k=8,m=1024)", "ore"].
+func splitTagParts(tag string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(tag); i++ {
+		switch tag[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				parts = append(parts, tag[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if start < len(tag) {
+		parts = append(parts, tag[start:])
+	}
+	return parts
+}
+
+// parseColumn builds a Column from the directives portion of a cs tag and the Go field type.
+func parseColumn(directives []string, fieldType reflect.Type) Column {
+	var castAs *CastAs
+	var indexes Indexes
+	hasIndex := false
+	autoJson := false
+
+	for _, d := range directives {
+		name, params := extractParams(d)
+
+		switch name {
+		case "cast":
+			ca := CastAs(params)
+			castAs = &ca
+		case "unique":
+			hasIndex = true
+			indexes.UniqueIndex = parseUniqueOpts(params)
+		case "match":
+			hasIndex = true
+			indexes.MatchIndex = parseMatchOpts(params)
+		case "ore":
+			hasIndex = true
+			indexes.OreIndex = &OreIndexOpts{}
+		case "ste_vec":
+			hasIndex = true
+			autoJson = true
+			indexes.SteVecIndex = parseSteVecOpts(params)
+		}
+	}
+
+	// Determine cast type.
+	if castAs == nil {
+		if autoJson {
+			ca := CastAsJson
+			castAs = &ca
+		} else {
+			ca := inferCastAs(fieldType)
+			castAs = &ca
+		}
+	}
+
+	col := Column{
+		CastAs: castAs,
+	}
+	if hasIndex {
+		col.Indexes = &indexes
+	}
+	return col
+}
+
+// parseMatchOpts parses the parameters string for a match index directive.
+// An empty params string returns the default match configuration.
+func parseMatchOpts(params string) *MatchIndexOpts {
+	// Defaults matching the TypeScript SDK.
+	tokenizerKind := "ngram"
+	tokenLength := 3
+	k := 6
+	m := 2048
+	includeOriginal := true
+
+	if params != "" {
+		kvs := parseKeyValues(params)
+		for key, val := range kvs {
+			switch key {
+			case "tokenizer":
+				tokenizerKind = val
+			case "token_length":
+				if n, err := strconv.Atoi(val); err == nil {
+					tokenLength = n
+				}
+			case "k":
+				if n, err := strconv.Atoi(val); err == nil {
+					k = n
+				}
+			case "m":
+				if n, err := strconv.Atoi(val); err == nil {
+					m = n
+				}
+			case "include_original":
+				if b, err := strconv.ParseBool(val); err == nil {
+					includeOriginal = b
+				}
+			}
+		}
+	}
+
+	opts := &MatchIndexOpts{
+		Tokenizer: &Tokenizer{
+			Kind: tokenizerKind,
+		},
+		TokenFilters:    []TokenFilter{{Kind: "downcase"}},
+		K:               &k,
+		M:               &m,
+		IncludeOriginal: &includeOriginal,
+	}
+
+	// Only set token_length for ngram tokenizer.
+	if tokenizerKind == "ngram" {
+		opts.Tokenizer.TokenLength = &tokenLength
+	}
+
+	return opts
+}
+
+// parseUniqueOpts parses the parameters string for a unique index directive.
+func parseUniqueOpts(params string) *UniqueIndexOpts {
+	opts := &UniqueIndexOpts{}
+	if params == "" {
+		return opts
+	}
+
+	// The params can be a simple keyword like "downcase" or key=value pairs.
+	if params == "downcase" {
+		opts.TokenFilters = []TokenFilter{{Kind: "downcase"}}
+		return opts
+	}
+
+	// Support key=value form as well.
+	kvs := parseKeyValues(params)
+	for key, val := range kvs {
+		if key == "token_filter" && val == "downcase" {
+			opts.TokenFilters = []TokenFilter{{Kind: "downcase"}}
+		}
+	}
+
+	return opts
+}
+
+// parseSteVecOpts parses the parameters string for a ste_vec index directive.
+func parseSteVecOpts(params string) *SteVecIndexOpts {
+	opts := &SteVecIndexOpts{}
+	if params == "" {
+		return opts
+	}
+
+	kvs := parseKeyValues(params)
+	for key, val := range kvs {
+		switch key {
+		case "prefix":
+			opts.Prefix = val
+		}
+	}
+
+	return opts
+}
+
+// inferCastAs determines the CastAs value from a Go reflect.Type.
+func inferCastAs(fieldType reflect.Type) CastAs {
+	// Dereference pointers.
+	for fieldType.Kind() == reflect.Ptr {
+		fieldType = fieldType.Elem()
+	}
+
+	switch fieldType.Kind() {
+	case reflect.String:
+		return CastAsString
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return CastAsNumber
+	case reflect.Float32, reflect.Float64:
+		return CastAsNumber
+	case reflect.Bool:
+		return CastAsBoolean
+	default:
+		// Maps, structs, interfaces, slices, arrays, etc.
+		return CastAsJson
+	}
+}
+
+// extractParams splits a directive like "match(k=8,m=1024)" into ("match", "k=8,m=1024")
+// and "ore" into ("ore", ""). For "cast=number", it returns ("cast", "number").
+func extractParams(directive string) (name string, params string) {
+	// Handle cast=<type> as a special case.
+	if strings.HasPrefix(directive, "cast=") {
+		return "cast", directive[5:]
+	}
+
+	// Handle directives with parenthesized parameters.
+	idx := strings.IndexByte(directive, '(')
+	if idx < 0 {
+		return directive, ""
+	}
+
+	name = directive[:idx]
+	// Strip the closing paren.
+	params = directive[idx+1:]
+	if len(params) > 0 && params[len(params)-1] == ')' {
+		params = params[:len(params)-1]
+	}
+	return name, params
+}
+
+// parseKeyValues parses a string like "k=8,m=1024,tokenizer=ngram" into a map.
+func parseKeyValues(s string) map[string]string {
+	result := make(map[string]string)
+	pairs := strings.Split(s, ",")
+	for _, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		eqIdx := strings.IndexByte(pair, '=')
+		if eqIdx < 0 {
+			// Bare keyword, store as key with empty value.
+			result[pair] = ""
+			continue
+		}
+		result[pair[:eqIdx]] = pair[eqIdx+1:]
+	}
+	return result
+}

--- a/pkg/protect/schema_test.go
+++ b/pkg/protect/schema_test.go
@@ -1,0 +1,775 @@
+package protect
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// --- Tag parsing tests ---
+
+func TestParseCSTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		tag            string
+		wantColumn     string
+		wantDirectives []string
+	}{
+		{
+			name:           "column name only",
+			tag:            "email",
+			wantColumn:     "email",
+			wantDirectives: nil,
+		},
+		{
+			name:           "column with single directive",
+			tag:            "email,unique",
+			wantColumn:     "email",
+			wantDirectives: []string{"unique"},
+		},
+		{
+			name:           "column with multiple directives",
+			tag:            "email,unique(downcase),match,ore",
+			wantColumn:     "email",
+			wantDirectives: []string{"unique(downcase)", "match", "ore"},
+		},
+		{
+			name:           "column with cast",
+			tag:            "age,cast=number",
+			wantColumn:     "age",
+			wantDirectives: []string{"cast=number"},
+		},
+		{
+			name:           "match with nested commas in params",
+			tag:            "name,match(k=8,m=1024)",
+			wantColumn:     "name",
+			wantDirectives: []string{"match(k=8,m=1024)"},
+		},
+		{
+			name:           "ste_vec with prefix",
+			tag:            "data,ste_vec(prefix=table/col)",
+			wantColumn:     "data",
+			wantDirectives: []string{"ste_vec(prefix=table/col)"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			col, dirs := parseCSTag(tc.tag)
+			if col != tc.wantColumn {
+				t.Errorf("column: got %q, want %q", col, tc.wantColumn)
+			}
+			if len(dirs) != len(tc.wantDirectives) {
+				t.Fatalf("directives count: got %d, want %d (got %v)", len(dirs), len(tc.wantDirectives), dirs)
+			}
+			for i, d := range dirs {
+				if d != tc.wantDirectives[i] {
+					t.Errorf("directive[%d]: got %q, want %q", i, d, tc.wantDirectives[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExtractParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		directive  string
+		wantName   string
+		wantParams string
+	}{
+		{"ore", "ore", ""},
+		{"unique", "unique", ""},
+		{"unique(downcase)", "unique", "downcase"},
+		{"match(k=8,m=1024)", "match", "k=8,m=1024"},
+		{"ste_vec(prefix=users/profile)", "ste_vec", "prefix=users/profile"},
+		{"cast=number", "cast", "number"},
+		{"cast=json", "cast", "json"},
+		{"match", "match", ""},
+		{"match(tokenizer=standard)", "match", "tokenizer=standard"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.directive, func(t *testing.T) {
+			t.Parallel()
+
+			name, params := extractParams(tc.directive)
+			if name != tc.wantName {
+				t.Errorf("name: got %q, want %q", name, tc.wantName)
+			}
+			if params != tc.wantParams {
+				t.Errorf("params: got %q, want %q", params, tc.wantParams)
+			}
+		})
+	}
+}
+
+// --- parseColumn / index parsing tests ---
+
+func TestParseColumnSimple(t *testing.T) {
+	t.Parallel()
+
+	// No directives, string field → CastAsString, no indexes.
+	col := parseColumn(nil, reflect.TypeOf(""))
+	if col.CastAs == nil || *col.CastAs != CastAsString {
+		t.Errorf("cast_as: got %v, want %q", col.CastAs, CastAsString)
+	}
+	if col.Indexes != nil {
+		t.Errorf("indexes: expected nil, got %+v", col.Indexes)
+	}
+}
+
+func TestParseColumnCastOverride(t *testing.T) {
+	t.Parallel()
+
+	col := parseColumn([]string{"cast=number"}, reflect.TypeOf(""))
+	if col.CastAs == nil || *col.CastAs != CastAsNumber {
+		t.Errorf("cast_as: got %v, want %q", col.CastAs, CastAsNumber)
+	}
+}
+
+func TestParseColumnUniqueIndex(t *testing.T) {
+	t.Parallel()
+
+	col := parseColumn([]string{"unique"}, reflect.TypeOf(""))
+	if col.Indexes == nil || col.Indexes.UniqueIndex == nil {
+		t.Fatal("expected unique index")
+	}
+	if len(col.Indexes.UniqueIndex.TokenFilters) != 0 {
+		t.Errorf("unique token filters: got %d, want 0", len(col.Indexes.UniqueIndex.TokenFilters))
+	}
+}
+
+func TestParseColumnUniqueDowncase(t *testing.T) {
+	t.Parallel()
+
+	col := parseColumn([]string{"unique(downcase)"}, reflect.TypeOf(""))
+	if col.Indexes == nil || col.Indexes.UniqueIndex == nil {
+		t.Fatal("expected unique index")
+	}
+	if len(col.Indexes.UniqueIndex.TokenFilters) != 1 {
+		t.Fatalf("unique token filters: got %d, want 1", len(col.Indexes.UniqueIndex.TokenFilters))
+	}
+	if col.Indexes.UniqueIndex.TokenFilters[0].Kind != "downcase" {
+		t.Errorf("token filter kind: got %q, want %q", col.Indexes.UniqueIndex.TokenFilters[0].Kind, "downcase")
+	}
+}
+
+func TestParseColumnMatchDefaults(t *testing.T) {
+	t.Parallel()
+
+	col := parseColumn([]string{"match"}, reflect.TypeOf(""))
+	if col.Indexes == nil || col.Indexes.MatchIndex == nil {
+		t.Fatal("expected match index")
+	}
+	mi := col.Indexes.MatchIndex
+
+	if mi.Tokenizer == nil || mi.Tokenizer.Kind != "ngram" {
+		t.Errorf("tokenizer kind: got %v, want %q", mi.Tokenizer, "ngram")
+	}
+	if mi.Tokenizer.TokenLength == nil || *mi.Tokenizer.TokenLength != 3 {
+		t.Errorf("token_length: got %v, want 3", mi.Tokenizer.TokenLength)
+	}
+	if mi.K == nil || *mi.K != 6 {
+		t.Errorf("k: got %v, want 6", mi.K)
+	}
+	if mi.M == nil || *mi.M != 2048 {
+		t.Errorf("m: got %v, want 2048", mi.M)
+	}
+	if mi.IncludeOriginal == nil || *mi.IncludeOriginal != true {
+		t.Errorf("include_original: got %v, want true", mi.IncludeOriginal)
+	}
+	if len(mi.TokenFilters) != 1 || mi.TokenFilters[0].Kind != "downcase" {
+		t.Errorf("token_filters: got %v, want [downcase]", mi.TokenFilters)
+	}
+}
+
+func TestParseColumnMatchCustomOpts(t *testing.T) {
+	t.Parallel()
+
+	col := parseColumn([]string{"match(tokenizer=standard,k=8)"}, reflect.TypeOf(""))
+	mi := col.Indexes.MatchIndex
+	if mi == nil {
+		t.Fatal("expected match index")
+	}
+
+	if mi.Tokenizer.Kind != "standard" {
+		t.Errorf("tokenizer: got %q, want %q", mi.Tokenizer.Kind, "standard")
+	}
+	// Standard tokenizer should not have token_length.
+	if mi.Tokenizer.TokenLength != nil {
+		t.Errorf("token_length: got %v, want nil for standard tokenizer", mi.Tokenizer.TokenLength)
+	}
+	if *mi.K != 8 {
+		t.Errorf("k: got %d, want 8", *mi.K)
+	}
+	// m should still be the default.
+	if *mi.M != 2048 {
+		t.Errorf("m: got %d, want 2048", *mi.M)
+	}
+}
+
+func TestParseColumnMatchNgramCustomTokenLength(t *testing.T) {
+	t.Parallel()
+
+	col := parseColumn([]string{"match(tokenizer=ngram,token_length=4,k=8)"}, reflect.TypeOf(""))
+	mi := col.Indexes.MatchIndex
+	if mi == nil {
+		t.Fatal("expected match index")
+	}
+	if mi.Tokenizer.Kind != "ngram" {
+		t.Errorf("tokenizer: got %q, want %q", mi.Tokenizer.Kind, "ngram")
+	}
+	if *mi.Tokenizer.TokenLength != 4 {
+		t.Errorf("token_length: got %d, want 4", *mi.Tokenizer.TokenLength)
+	}
+	if *mi.K != 8 {
+		t.Errorf("k: got %d, want 8", *mi.K)
+	}
+}
+
+func TestParseColumnOreIndex(t *testing.T) {
+	t.Parallel()
+
+	col := parseColumn([]string{"ore"}, reflect.TypeOf(0))
+	if col.Indexes == nil || col.Indexes.OreIndex == nil {
+		t.Fatal("expected ore index")
+	}
+}
+
+func TestParseColumnSteVec(t *testing.T) {
+	t.Parallel()
+
+	col := parseColumn([]string{"ste_vec(prefix=users/profile)"}, reflect.TypeOf((*interface{})(nil)).Elem())
+	if col.Indexes == nil || col.Indexes.SteVecIndex == nil {
+		t.Fatal("expected ste_vec index")
+	}
+	if col.Indexes.SteVecIndex.Prefix != "users/profile" {
+		t.Errorf("prefix: got %q, want %q", col.Indexes.SteVecIndex.Prefix, "users/profile")
+	}
+	// SteVec should auto-set cast to json.
+	if col.CastAs == nil || *col.CastAs != CastAsJson {
+		t.Errorf("cast_as: got %v, want %q", col.CastAs, CastAsJson)
+	}
+}
+
+func TestParseColumnMultipleIndexes(t *testing.T) {
+	t.Parallel()
+
+	col := parseColumn([]string{"unique(downcase)", "match", "ore"}, reflect.TypeOf(""))
+	if col.Indexes == nil {
+		t.Fatal("expected indexes")
+	}
+	if col.Indexes.UniqueIndex == nil {
+		t.Error("expected unique index")
+	}
+	if col.Indexes.MatchIndex == nil {
+		t.Error("expected match index")
+	}
+	if col.Indexes.OreIndex == nil {
+		t.Error("expected ore index")
+	}
+}
+
+// --- Type inference tests ---
+
+func TestInferCastAs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		typ      reflect.Type
+		wantCast CastAs
+	}{
+		{"string", reflect.TypeOf(""), CastAsString},
+		{"int", reflect.TypeOf(0), CastAsNumber},
+		{"int8", reflect.TypeOf(int8(0)), CastAsNumber},
+		{"int16", reflect.TypeOf(int16(0)), CastAsNumber},
+		{"int32", reflect.TypeOf(int32(0)), CastAsNumber},
+		{"int64", reflect.TypeOf(int64(0)), CastAsNumber},
+		{"uint", reflect.TypeOf(uint(0)), CastAsNumber},
+		{"uint8", reflect.TypeOf(uint8(0)), CastAsNumber},
+		{"uint16", reflect.TypeOf(uint16(0)), CastAsNumber},
+		{"uint32", reflect.TypeOf(uint32(0)), CastAsNumber},
+		{"uint64", reflect.TypeOf(uint64(0)), CastAsNumber},
+		{"float32", reflect.TypeOf(float32(0)), CastAsNumber},
+		{"float64", reflect.TypeOf(float64(0)), CastAsNumber},
+		{"bool", reflect.TypeOf(false), CastAsBoolean},
+		{"map", reflect.TypeOf(map[string]interface{}{}), CastAsJson},
+		{"slice", reflect.TypeOf([]string{}), CastAsJson},
+		{"interface", reflect.TypeOf((*interface{})(nil)).Elem(), CastAsJson},
+		{"*string", reflect.TypeOf((*string)(nil)), CastAsString},
+		{"*int", reflect.TypeOf((*int)(nil)), CastAsNumber},
+		{"*bool", reflect.TypeOf((*bool)(nil)), CastAsBoolean},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := inferCastAs(tc.typ)
+			if got != tc.wantCast {
+				t.Errorf("inferCastAs(%v) = %q, want %q", tc.typ, got, tc.wantCast)
+			}
+		})
+	}
+}
+
+func TestCastOverrideBeatsInference(t *testing.T) {
+	t.Parallel()
+
+	// String field with explicit cast=number.
+	col := parseColumn([]string{"cast=number"}, reflect.TypeOf(""))
+	if col.CastAs == nil || *col.CastAs != CastAsNumber {
+		t.Errorf("cast_as: got %v, want %q", col.CastAs, CastAsNumber)
+	}
+}
+
+// --- TableSchema tests ---
+
+type schemaTestUser struct {
+	ID      int    `json:"id"`
+	Email   string `json:"email"   cs:"email,unique(downcase),match"`
+	Name    string `json:"name"    cs:"name,match"`
+	Age     int    `json:"age"     cs:"age,cast=number,ore"`
+	Active  bool   `json:"active"  cs:"active,cast=boolean"`
+	Profile any    `json:"profile" cs:"profile,ste_vec(prefix=users/profile)"`
+	Role    string `json:"role"`
+}
+
+func TestTableSchemaFullStruct(t *testing.T) {
+	t.Parallel()
+
+	td := TableSchema("users", schemaTestUser{})
+
+	if td.Name != "users" {
+		t.Errorf("table name: got %q, want %q", td.Name, "users")
+	}
+
+	// Should have 5 encrypted columns: email, name, age, active, profile.
+	if len(td.Columns) != 5 {
+		t.Fatalf("columns count: got %d, want 5 (columns: %v)", len(td.Columns), columnNames(td.Columns))
+	}
+
+	// Verify email column.
+	email, ok := td.Columns["email"]
+	if !ok {
+		t.Fatal("missing email column")
+	}
+	if *email.CastAs != CastAsString {
+		t.Errorf("email cast_as: got %q, want %q", *email.CastAs, CastAsString)
+	}
+	if email.Indexes == nil {
+		t.Fatal("email indexes: expected non-nil")
+	}
+	if email.Indexes.UniqueIndex == nil {
+		t.Error("email: expected unique index")
+	}
+	if email.Indexes.MatchIndex == nil {
+		t.Error("email: expected match index")
+	}
+
+	// Verify age column.
+	age, ok := td.Columns["age"]
+	if !ok {
+		t.Fatal("missing age column")
+	}
+	if *age.CastAs != CastAsNumber {
+		t.Errorf("age cast_as: got %q, want %q", *age.CastAs, CastAsNumber)
+	}
+	if age.Indexes == nil || age.Indexes.OreIndex == nil {
+		t.Error("age: expected ore index")
+	}
+
+	// Verify profile column.
+	profile, ok := td.Columns["profile"]
+	if !ok {
+		t.Fatal("missing profile column")
+	}
+	if *profile.CastAs != CastAsJson {
+		t.Errorf("profile cast_as: got %q, want %q", *profile.CastAs, CastAsJson)
+	}
+	if profile.Indexes == nil || profile.Indexes.SteVecIndex == nil {
+		t.Fatal("profile: expected ste_vec index")
+	}
+	if profile.Indexes.SteVecIndex.Prefix != "users/profile" {
+		t.Errorf("profile prefix: got %q, want %q", profile.Indexes.SteVecIndex.Prefix, "users/profile")
+	}
+
+	// Verify "Role" is not present (no cs tag).
+	if _, ok := td.Columns["role"]; ok {
+		t.Error("role should not be in columns (no cs tag)")
+	}
+}
+
+func TestTableSchemaPointerModel(t *testing.T) {
+	t.Parallel()
+
+	td := TableSchema("users", &schemaTestUser{})
+	if td.Name != "users" {
+		t.Errorf("table name: got %q, want %q", td.Name, "users")
+	}
+	if len(td.Columns) != 5 {
+		t.Errorf("columns count: got %d, want 5", len(td.Columns))
+	}
+}
+
+type noCSTagSchema struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestTableSchemaNoCSTagsEmptyColumns(t *testing.T) {
+	t.Parallel()
+
+	td := TableSchema("empty", noCSTagSchema{})
+	if len(td.Columns) != 0 {
+		t.Errorf("columns count: got %d, want 0", len(td.Columns))
+	}
+}
+
+func TestTableSchemaPanicsOnNonStruct(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for non-struct model")
+		}
+	}()
+	TableSchema("test", "not a struct")
+}
+
+func TestTableSchemaPanicsOnNil(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for nil model")
+		}
+	}()
+	TableSchema("test", nil)
+}
+
+// --- BuildEncryptConfig tests ---
+
+func TestBuildEncryptConfigSingleTable(t *testing.T) {
+	t.Parallel()
+
+	td := TableSchema("users", schemaTestUser{})
+	config := BuildEncryptConfig(td)
+
+	if config.Version != 1 {
+		t.Errorf("version: got %d, want 1", config.Version)
+	}
+	if len(config.Tables) != 1 {
+		t.Fatalf("tables count: got %d, want 1", len(config.Tables))
+	}
+	if _, ok := config.Tables["users"]; !ok {
+		t.Fatal("missing users table")
+	}
+}
+
+type schemaTestProduct struct {
+	ID    int    `json:"id"`
+	Name  string `json:"name" cs:"name,match"`
+	Price int    `json:"price" cs:"price,cast=number,ore"`
+}
+
+func TestBuildEncryptConfigMultipleTables(t *testing.T) {
+	t.Parallel()
+
+	users := TableSchema("users", schemaTestUser{})
+	products := TableSchema("products", schemaTestProduct{})
+	config := BuildEncryptConfig(users, products)
+
+	if len(config.Tables) != 2 {
+		t.Fatalf("tables count: got %d, want 2", len(config.Tables))
+	}
+	if _, ok := config.Tables["users"]; !ok {
+		t.Error("missing users table")
+	}
+	if _, ok := config.Tables["products"]; !ok {
+		t.Error("missing products table")
+	}
+}
+
+// --- Edge case tests ---
+
+type skipDashSchema struct {
+	ID    int    `json:"id"`
+	Email string `json:"email" cs:"-"`
+}
+
+func TestTableSchemaSkipDashTag(t *testing.T) {
+	t.Parallel()
+
+	td := TableSchema("test", skipDashSchema{})
+	if len(td.Columns) != 0 {
+		t.Errorf("columns count: got %d, want 0", len(td.Columns))
+	}
+}
+
+type emptyCSSchema struct {
+	ID    int    `json:"id"`
+	Email string `json:"email" cs:""`
+}
+
+func TestTableSchemaSkipEmptyTag(t *testing.T) {
+	t.Parallel()
+
+	td := TableSchema("test", emptyCSSchema{})
+	if len(td.Columns) != 0 {
+		t.Errorf("columns count: got %d, want 0", len(td.Columns))
+	}
+}
+
+type unexportedSchema struct {
+	ID    int    `json:"id"`
+	Email string `json:"email" cs:"email,unique"`
+	//nolint:unused
+	secret string `cs:"secret,unique"`
+}
+
+func TestTableSchemaSkipsUnexportedFields(t *testing.T) {
+	t.Parallel()
+
+	td := TableSchema("test", unexportedSchema{})
+	if len(td.Columns) != 1 {
+		t.Errorf("columns count: got %d, want 1", len(td.Columns))
+	}
+	if _, ok := td.Columns["email"]; !ok {
+		t.Error("missing email column")
+	}
+}
+
+type pointerFieldSchema struct {
+	ID    int     `json:"id"`
+	Email *string `json:"email" cs:"email,unique"`
+	Age   *int    `json:"age" cs:"age,ore"`
+	Ok    *bool   `json:"ok" cs:"ok"`
+}
+
+func TestTableSchemaPointerFieldTypeInference(t *testing.T) {
+	t.Parallel()
+
+	td := TableSchema("test", pointerFieldSchema{})
+
+	email := td.Columns["email"]
+	if *email.CastAs != CastAsString {
+		t.Errorf("email cast_as: got %q, want %q", *email.CastAs, CastAsString)
+	}
+
+	age := td.Columns["age"]
+	if *age.CastAs != CastAsNumber {
+		t.Errorf("age cast_as: got %q, want %q", *age.CastAs, CastAsNumber)
+	}
+
+	ok := td.Columns["ok"]
+	if *ok.CastAs != CastAsBoolean {
+		t.Errorf("ok cast_as: got %q, want %q", *ok.CastAs, CastAsBoolean)
+	}
+}
+
+// --- JSON serialization test ---
+
+func TestBuildEncryptConfigJSONOutput(t *testing.T) {
+	t.Parallel()
+
+	type simpleModel struct {
+		Email string `json:"email" cs:"email,unique(downcase),match"`
+		Age   int    `json:"age" cs:"age,cast=number,ore"`
+	}
+
+	td := TableSchema("users", simpleModel{})
+	config := BuildEncryptConfig(td)
+
+	data, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	// Unmarshal into a generic map to verify structure.
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	// Verify top-level structure.
+	if v, ok := result["v"]; !ok || v != float64(1) {
+		t.Errorf("version: got %v, want 1", result["v"])
+	}
+
+	tables, ok := result["tables"].(map[string]interface{})
+	if !ok {
+		t.Fatal("tables: not a map")
+	}
+
+	users, ok := tables["users"].(map[string]interface{})
+	if !ok {
+		t.Fatal("users table: not a map")
+	}
+
+	// Verify email column has unique and match indexes.
+	emailCol, ok := users["email"].(map[string]interface{})
+	if !ok {
+		t.Fatal("email column: not a map")
+	}
+	if emailCol["cast_as"] != "string" {
+		t.Errorf("email cast_as: got %v, want %q", emailCol["cast_as"], "string")
+	}
+
+	emailIndexes, ok := emailCol["indexes"].(map[string]interface{})
+	if !ok {
+		t.Fatal("email indexes: not a map")
+	}
+	if _, ok := emailIndexes["unique"]; !ok {
+		t.Error("email: missing unique index in JSON")
+	}
+	if _, ok := emailIndexes["match"]; !ok {
+		t.Error("email: missing match index in JSON")
+	}
+
+	// Verify age column has ore index.
+	ageCol, ok := users["age"].(map[string]interface{})
+	if !ok {
+		t.Fatal("age column: not a map")
+	}
+	if ageCol["cast_as"] != "number" {
+		t.Errorf("age cast_as: got %v, want %q", ageCol["cast_as"], "number")
+	}
+
+	ageIndexes, ok := ageCol["indexes"].(map[string]interface{})
+	if !ok {
+		t.Fatal("age indexes: not a map")
+	}
+	if _, ok := ageIndexes["ore"]; !ok {
+		t.Error("age: missing ore index in JSON")
+	}
+}
+
+// --- Integration: full round-trip test ---
+
+func TestBuildEncryptConfigIntegration(t *testing.T) {
+	t.Parallel()
+
+	td := TableSchema("users", schemaTestUser{})
+	config := BuildEncryptConfig(td)
+
+	data, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	// Unmarshal back into EncryptConfig to verify round-trip.
+	var roundTripped EncryptConfig
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if roundTripped.Version != 1 {
+		t.Errorf("version: got %d, want 1", roundTripped.Version)
+	}
+	if len(roundTripped.Tables) != 1 {
+		t.Fatalf("tables: got %d, want 1", len(roundTripped.Tables))
+	}
+
+	usersTable := roundTripped.Tables["users"]
+	if len(usersTable) != 5 {
+		t.Fatalf("user columns: got %d, want 5", len(usersTable))
+	}
+
+	// Verify match index on email survived round-trip.
+	email := usersTable["email"]
+	if email.Indexes == nil || email.Indexes.MatchIndex == nil {
+		t.Fatal("email match index lost in round-trip")
+	}
+	if email.Indexes.MatchIndex.Tokenizer.Kind != "ngram" {
+		t.Errorf("email match tokenizer: got %q, want %q", email.Indexes.MatchIndex.Tokenizer.Kind, "ngram")
+	}
+	if *email.Indexes.MatchIndex.K != 6 {
+		t.Errorf("email match k: got %d, want 6", *email.Indexes.MatchIndex.K)
+	}
+}
+
+// --- Test analyzeStruct still works with extended cs tags ---
+
+func TestAnalyzeStructWithExtendedTags(t *testing.T) {
+	t.Parallel()
+
+	info, err := analyzeStruct(reflect.TypeOf(schemaTestUser{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// analyzeStruct should extract just the column name from the extended tag.
+	if len(info.EncryptedFields) != 5 {
+		t.Fatalf("encrypted fields: got %d, want 5", len(info.EncryptedFields))
+	}
+
+	expectedColumns := map[string]bool{
+		"email":   true,
+		"name":    true,
+		"age":     true,
+		"active":  true,
+		"profile": true,
+	}
+	for _, ef := range info.EncryptedFields {
+		if !expectedColumns[ef.Column] {
+			t.Errorf("unexpected column %q (full tag value leaked?)", ef.Column)
+		}
+	}
+}
+
+// --- splitTagParts tests ---
+
+func TestSplitTagParts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"email", []string{"email"}},
+		{"email,unique", []string{"email", "unique"}},
+		{"email,match(k=8,m=1024)", []string{"email", "match(k=8,m=1024)"}},
+		{"email,match(k=8,m=1024),ore", []string{"email", "match(k=8,m=1024)", "ore"}},
+		{"email,unique(downcase),match(tokenizer=ngram,token_length=3,k=6),ore", []string{
+			"email", "unique(downcase)", "match(tokenizer=ngram,token_length=3,k=6)", "ore",
+		}},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := splitTagParts(tc.input)
+			if len(got) != len(tc.want) {
+				t.Fatalf("parts count: got %d (%v), want %d (%v)", len(got), got, len(tc.want), tc.want)
+			}
+			for i, part := range got {
+				if part != tc.want[i] {
+					t.Errorf("part[%d]: got %q, want %q", i, part, tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// --- Helpers ---
+
+func columnNames(cols map[string]Column) []string {
+	names := make([]string, 0, len(cols))
+	for k := range cols {
+		names = append(names, k)
+	}
+	return names
+}

--- a/pkg/protect/schema_test.go
+++ b/pkg/protect/schema_test.go
@@ -251,8 +251,8 @@ func TestParseColumnSteVec(t *testing.T) {
 	if col.Indexes.SteVecIndex.Prefix != "users/profile" {
 		t.Errorf("prefix: got %q, want %q", col.Indexes.SteVecIndex.Prefix, "users/profile")
 	}
-	if col.CastAs == nil || *col.CastAs != CastAsJson {
-		t.Errorf("cast_as: got %v, want %q", col.CastAs, CastAsJson)
+	if col.CastAs == nil || *col.CastAs != CastAsJSON {
+		t.Errorf("cast_as: got %v, want %q", col.CastAs, CastAsJSON)
 	}
 }
 
@@ -298,9 +298,9 @@ func TestInferCastAs(t *testing.T) {
 		{"float32", reflect.TypeOf(float32(0)), CastAsNumber},
 		{"float64", reflect.TypeOf(float64(0)), CastAsNumber},
 		{"bool", reflect.TypeOf(false), CastAsBoolean},
-		{"map", reflect.TypeOf(map[string]any{}), CastAsJson},
-		{"slice", reflect.TypeOf([]string{}), CastAsJson},
-		{"interface", reflect.TypeOf((*any)(nil)).Elem(), CastAsJson},
+		{"map", reflect.TypeOf(map[string]any{}), CastAsJSON},
+		{"slice", reflect.TypeOf([]string{}), CastAsJSON},
+		{"interface", reflect.TypeOf((*any)(nil)).Elem(), CastAsJSON},
 		{"*string", reflect.TypeOf((*string)(nil)), CastAsString},
 		{"*int", reflect.TypeOf((*int)(nil)), CastAsNumber},
 		{"*bool", reflect.TypeOf((*bool)(nil)), CastAsBoolean},
@@ -392,8 +392,8 @@ func TestTableSchemaFullStruct(t *testing.T) {
 	if !ok {
 		t.Fatal("missing profile column")
 	}
-	if *profile.CastAs != CastAsJson {
-		t.Errorf("profile cast_as: got %q, want %q", *profile.CastAs, CastAsJson)
+	if *profile.CastAs != CastAsJSON {
+		t.Errorf("profile cast_as: got %q, want %q", *profile.CastAs, CastAsJSON)
 	}
 	if profile.Indexes == nil || profile.Indexes.SteVecIndex == nil {
 		t.Fatal("profile: expected ste_vec index")
@@ -475,6 +475,28 @@ func TestTableDefColumn(t *testing.T) {
 	}
 	if col.column != "email" {
 		t.Errorf("column: got %q, want %q", col.column, "email")
+	}
+}
+
+func TestTableDefColumnOK(t *testing.T) {
+	t.Parallel()
+
+	td, err := TableSchema("users", schemaTestUser{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
+	}
+
+	col, ok := td.ColumnOK("email")
+	if !ok {
+		t.Fatal("expected email column to exist")
+	}
+	if col.table != "users" || col.column != "email" {
+		t.Errorf("ColumnOK: got table=%q column=%q", col.table, col.column)
+	}
+
+	_, ok = td.ColumnOK("nonexistent")
+	if ok {
+		t.Fatal("expected nonexistent column to not exist")
 	}
 }
 
@@ -873,8 +895,8 @@ func TestSchemaBuilderSearchableJSON(t *testing.T) {
 		Build()
 
 	meta := td.columns["metadata"]
-	if *meta.CastAs != CastAsJson {
-		t.Errorf("cast_as: got %q, want %q", *meta.CastAs, CastAsJson)
+	if *meta.CastAs != CastAsJSON {
+		t.Errorf("cast_as: got %q, want %q", *meta.CastAs, CastAsJSON)
 	}
 	if meta.Indexes == nil || meta.Indexes.SteVecIndex == nil {
 		t.Fatal("expected ste_vec index")

--- a/pkg/protect/schema_test.go
+++ b/pkg/protect/schema_test.go
@@ -116,7 +116,6 @@ func TestExtractParams(t *testing.T) {
 func TestParseColumnSimple(t *testing.T) {
 	t.Parallel()
 
-	// No directives, string field → CastAsString, no indexes.
 	col := parseColumn(nil, reflect.TypeOf(""))
 	if col.CastAs == nil || *col.CastAs != CastAsString {
 		t.Errorf("cast_as: got %v, want %q", col.CastAs, CastAsString)
@@ -203,14 +202,12 @@ func TestParseColumnMatchCustomOpts(t *testing.T) {
 	if mi.Tokenizer.Kind != "standard" {
 		t.Errorf("tokenizer: got %q, want %q", mi.Tokenizer.Kind, "standard")
 	}
-	// Standard tokenizer should not have token_length.
 	if mi.Tokenizer.TokenLength != nil {
 		t.Errorf("token_length: got %v, want nil for standard tokenizer", mi.Tokenizer.TokenLength)
 	}
 	if *mi.K != 8 {
 		t.Errorf("k: got %d, want 8", *mi.K)
 	}
-	// m should still be the default.
 	if *mi.M != 2048 {
 		t.Errorf("m: got %d, want 2048", *mi.M)
 	}
@@ -247,14 +244,13 @@ func TestParseColumnOreIndex(t *testing.T) {
 func TestParseColumnSteVec(t *testing.T) {
 	t.Parallel()
 
-	col := parseColumn([]string{"ste_vec(prefix=users/profile)"}, reflect.TypeOf((*interface{})(nil)).Elem())
+	col := parseColumn([]string{"ste_vec(prefix=users/profile)"}, reflect.TypeOf((*any)(nil)).Elem())
 	if col.Indexes == nil || col.Indexes.SteVecIndex == nil {
 		t.Fatal("expected ste_vec index")
 	}
 	if col.Indexes.SteVecIndex.Prefix != "users/profile" {
 		t.Errorf("prefix: got %q, want %q", col.Indexes.SteVecIndex.Prefix, "users/profile")
 	}
-	// SteVec should auto-set cast to json.
 	if col.CastAs == nil || *col.CastAs != CastAsJson {
 		t.Errorf("cast_as: got %v, want %q", col.CastAs, CastAsJson)
 	}
@@ -302,9 +298,9 @@ func TestInferCastAs(t *testing.T) {
 		{"float32", reflect.TypeOf(float32(0)), CastAsNumber},
 		{"float64", reflect.TypeOf(float64(0)), CastAsNumber},
 		{"bool", reflect.TypeOf(false), CastAsBoolean},
-		{"map", reflect.TypeOf(map[string]interface{}{}), CastAsJson},
+		{"map", reflect.TypeOf(map[string]any{}), CastAsJson},
 		{"slice", reflect.TypeOf([]string{}), CastAsJson},
-		{"interface", reflect.TypeOf((*interface{})(nil)).Elem(), CastAsJson},
+		{"interface", reflect.TypeOf((*any)(nil)).Elem(), CastAsJson},
 		{"*string", reflect.TypeOf((*string)(nil)), CastAsString},
 		{"*int", reflect.TypeOf((*int)(nil)), CastAsNumber},
 		{"*bool", reflect.TypeOf((*bool)(nil)), CastAsBoolean},
@@ -326,7 +322,6 @@ func TestInferCastAs(t *testing.T) {
 func TestCastOverrideBeatsInference(t *testing.T) {
 	t.Parallel()
 
-	// String field with explicit cast=number.
 	col := parseColumn([]string{"cast=number"}, reflect.TypeOf(""))
 	if col.CastAs == nil || *col.CastAs != CastAsNumber {
 		t.Errorf("cast_as: got %v, want %q", col.CastAs, CastAsNumber)
@@ -348,19 +343,22 @@ type schemaTestUser struct {
 func TestTableSchemaFullStruct(t *testing.T) {
 	t.Parallel()
 
-	td := TableSchema("users", schemaTestUser{})
+	td, err := TableSchema("users", schemaTestUser{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
+	}
 
-	if td.Name != "users" {
-		t.Errorf("table name: got %q, want %q", td.Name, "users")
+	if td.Name() != "users" {
+		t.Errorf("table name: got %q, want %q", td.Name(), "users")
 	}
 
 	// Should have 5 encrypted columns: email, name, age, active, profile.
-	if len(td.Columns) != 5 {
-		t.Fatalf("columns count: got %d, want 5 (columns: %v)", len(td.Columns), columnNames(td.Columns))
+	if len(td.columns) != 5 {
+		t.Fatalf("columns count: got %d, want 5 (columns: %v)", len(td.columns), columnNames(td.columns))
 	}
 
 	// Verify email column.
-	email, ok := td.Columns["email"]
+	email, ok := td.columns["email"]
 	if !ok {
 		t.Fatal("missing email column")
 	}
@@ -378,7 +376,7 @@ func TestTableSchemaFullStruct(t *testing.T) {
 	}
 
 	// Verify age column.
-	age, ok := td.Columns["age"]
+	age, ok := td.columns["age"]
 	if !ok {
 		t.Fatal("missing age column")
 	}
@@ -390,7 +388,7 @@ func TestTableSchemaFullStruct(t *testing.T) {
 	}
 
 	// Verify profile column.
-	profile, ok := td.Columns["profile"]
+	profile, ok := td.columns["profile"]
 	if !ok {
 		t.Fatal("missing profile column")
 	}
@@ -405,7 +403,7 @@ func TestTableSchemaFullStruct(t *testing.T) {
 	}
 
 	// Verify "Role" is not present (no cs tag).
-	if _, ok := td.Columns["role"]; ok {
+	if _, ok := td.columns["role"]; ok {
 		t.Error("role should not be in columns (no cs tag)")
 	}
 }
@@ -413,12 +411,16 @@ func TestTableSchemaFullStruct(t *testing.T) {
 func TestTableSchemaPointerModel(t *testing.T) {
 	t.Parallel()
 
-	td := TableSchema("users", &schemaTestUser{})
-	if td.Name != "users" {
-		t.Errorf("table name: got %q, want %q", td.Name, "users")
+	td, err := TableSchema("users", &schemaTestUser{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
 	}
-	if len(td.Columns) != 5 {
-		t.Errorf("columns count: got %d, want 5", len(td.Columns))
+
+	if td.Name() != "users" {
+		t.Errorf("table name: got %q, want %q", td.Name(), "users")
+	}
+	if len(td.columns) != 5 {
+		t.Errorf("columns count: got %d, want 5", len(td.columns))
 	}
 }
 
@@ -430,41 +432,79 @@ type noCSTagSchema struct {
 func TestTableSchemaNoCSTagsEmptyColumns(t *testing.T) {
 	t.Parallel()
 
-	td := TableSchema("empty", noCSTagSchema{})
-	if len(td.Columns) != 0 {
-		t.Errorf("columns count: got %d, want 0", len(td.Columns))
+	td, err := TableSchema("empty", noCSTagSchema{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
+	}
+	if len(td.columns) != 0 {
+		t.Errorf("columns count: got %d, want 0", len(td.columns))
 	}
 }
 
-func TestTableSchemaPanicsOnNonStruct(t *testing.T) {
+func TestTableSchemaReturnsErrorOnNonStruct(t *testing.T) {
 	t.Parallel()
+
+	_, err := TableSchema("test", "not a struct")
+	if err == nil {
+		t.Fatal("expected error for non-struct model")
+	}
+}
+
+func TestTableSchemaReturnsErrorOnNil(t *testing.T) {
+	t.Parallel()
+
+	_, err := TableSchema("test", nil)
+	if err == nil {
+		t.Fatal("expected error for nil model")
+	}
+}
+
+// --- ColumnRef tests ---
+
+func TestTableDefColumn(t *testing.T) {
+	t.Parallel()
+
+	td, err := TableSchema("users", schemaTestUser{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
+	}
+
+	col := td.Column("email")
+	if col.table != "users" {
+		t.Errorf("table: got %q, want %q", col.table, "users")
+	}
+	if col.column != "email" {
+		t.Errorf("column: got %q, want %q", col.column, "email")
+	}
+}
+
+func TestTableDefColumnPanicsOnUnknown(t *testing.T) {
+	t.Parallel()
+
+	td, err := TableSchema("users", schemaTestUser{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
+	}
 
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for non-struct model")
+			t.Fatal("expected panic for unknown column")
 		}
 	}()
-	TableSchema("test", "not a struct")
+	td.Column("nonexistent")
 }
 
-func TestTableSchemaPanicsOnNil(t *testing.T) {
+// --- buildEncryptConfigFromSchemas tests ---
+
+func TestBuildEncryptConfigFromSchemasSingleTable(t *testing.T) {
 	t.Parallel()
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for nil model")
-		}
-	}()
-	TableSchema("test", nil)
-}
+	td, err := TableSchema("users", schemaTestUser{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
+	}
 
-// --- BuildEncryptConfig tests ---
-
-func TestBuildEncryptConfigSingleTable(t *testing.T) {
-	t.Parallel()
-
-	td := TableSchema("users", schemaTestUser{})
-	config := BuildEncryptConfig(td)
+	config := buildEncryptConfigFromSchemas([]*TableDef{td})
 
 	if config.Version != 1 {
 		t.Errorf("version: got %d, want 1", config.Version)
@@ -483,12 +523,19 @@ type schemaTestProduct struct {
 	Price int    `json:"price" cs:"price,cast=number,ore"`
 }
 
-func TestBuildEncryptConfigMultipleTables(t *testing.T) {
+func TestBuildEncryptConfigFromSchemasMultipleTables(t *testing.T) {
 	t.Parallel()
 
-	users := TableSchema("users", schemaTestUser{})
-	products := TableSchema("products", schemaTestProduct{})
-	config := BuildEncryptConfig(users, products)
+	users, err := TableSchema("users", schemaTestUser{})
+	if err != nil {
+		t.Fatalf("TableSchema users: %v", err)
+	}
+	products, err := TableSchema("products", schemaTestProduct{})
+	if err != nil {
+		t.Fatalf("TableSchema products: %v", err)
+	}
+
+	config := buildEncryptConfigFromSchemas([]*TableDef{users, products})
 
 	if len(config.Tables) != 2 {
 		t.Fatalf("tables count: got %d, want 2", len(config.Tables))
@@ -511,9 +558,12 @@ type skipDashSchema struct {
 func TestTableSchemaSkipDashTag(t *testing.T) {
 	t.Parallel()
 
-	td := TableSchema("test", skipDashSchema{})
-	if len(td.Columns) != 0 {
-		t.Errorf("columns count: got %d, want 0", len(td.Columns))
+	td, err := TableSchema("test", skipDashSchema{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
+	}
+	if len(td.columns) != 0 {
+		t.Errorf("columns count: got %d, want 0", len(td.columns))
 	}
 }
 
@@ -525,9 +575,12 @@ type emptyCSSchema struct {
 func TestTableSchemaSkipEmptyTag(t *testing.T) {
 	t.Parallel()
 
-	td := TableSchema("test", emptyCSSchema{})
-	if len(td.Columns) != 0 {
-		t.Errorf("columns count: got %d, want 0", len(td.Columns))
+	td, err := TableSchema("test", emptyCSSchema{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
+	}
+	if len(td.columns) != 0 {
+		t.Errorf("columns count: got %d, want 0", len(td.columns))
 	}
 }
 
@@ -541,11 +594,14 @@ type unexportedSchema struct {
 func TestTableSchemaSkipsUnexportedFields(t *testing.T) {
 	t.Parallel()
 
-	td := TableSchema("test", unexportedSchema{})
-	if len(td.Columns) != 1 {
-		t.Errorf("columns count: got %d, want 1", len(td.Columns))
+	td, err := TableSchema("test", unexportedSchema{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
 	}
-	if _, ok := td.Columns["email"]; !ok {
+	if len(td.columns) != 1 {
+		t.Errorf("columns count: got %d, want 1", len(td.columns))
+	}
+	if _, ok := td.columns["email"]; !ok {
 		t.Error("missing email column")
 	}
 }
@@ -560,19 +616,22 @@ type pointerFieldSchema struct {
 func TestTableSchemaPointerFieldTypeInference(t *testing.T) {
 	t.Parallel()
 
-	td := TableSchema("test", pointerFieldSchema{})
+	td, err := TableSchema("test", pointerFieldSchema{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
+	}
 
-	email := td.Columns["email"]
+	email := td.columns["email"]
 	if *email.CastAs != CastAsString {
 		t.Errorf("email cast_as: got %q, want %q", *email.CastAs, CastAsString)
 	}
 
-	age := td.Columns["age"]
+	age := td.columns["age"]
 	if *age.CastAs != CastAsNumber {
 		t.Errorf("age cast_as: got %q, want %q", *age.CastAs, CastAsNumber)
 	}
 
-	ok := td.Columns["ok"]
+	ok := td.columns["ok"]
 	if *ok.CastAs != CastAsBoolean {
 		t.Errorf("ok cast_as: got %q, want %q", *ok.CastAs, CastAsBoolean)
 	}
@@ -588,37 +647,37 @@ func TestBuildEncryptConfigJSONOutput(t *testing.T) {
 		Age   int    `json:"age" cs:"age,cast=number,ore"`
 	}
 
-	td := TableSchema("users", simpleModel{})
-	config := BuildEncryptConfig(td)
+	td, err := TableSchema("users", simpleModel{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
+	}
+	config := buildEncryptConfigFromSchemas([]*TableDef{td})
 
 	data, err := json.Marshal(config)
 	if err != nil {
 		t.Fatalf("json.Marshal: %v", err)
 	}
 
-	// Unmarshal into a generic map to verify structure.
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal(data, &result); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
 
-	// Verify top-level structure.
 	if v, ok := result["v"]; !ok || v != float64(1) {
 		t.Errorf("version: got %v, want 1", result["v"])
 	}
 
-	tables, ok := result["tables"].(map[string]interface{})
+	tables, ok := result["tables"].(map[string]any)
 	if !ok {
 		t.Fatal("tables: not a map")
 	}
 
-	users, ok := tables["users"].(map[string]interface{})
+	users, ok := tables["users"].(map[string]any)
 	if !ok {
 		t.Fatal("users table: not a map")
 	}
 
-	// Verify email column has unique and match indexes.
-	emailCol, ok := users["email"].(map[string]interface{})
+	emailCol, ok := users["email"].(map[string]any)
 	if !ok {
 		t.Fatal("email column: not a map")
 	}
@@ -626,7 +685,7 @@ func TestBuildEncryptConfigJSONOutput(t *testing.T) {
 		t.Errorf("email cast_as: got %v, want %q", emailCol["cast_as"], "string")
 	}
 
-	emailIndexes, ok := emailCol["indexes"].(map[string]interface{})
+	emailIndexes, ok := emailCol["indexes"].(map[string]any)
 	if !ok {
 		t.Fatal("email indexes: not a map")
 	}
@@ -637,8 +696,7 @@ func TestBuildEncryptConfigJSONOutput(t *testing.T) {
 		t.Error("email: missing match index in JSON")
 	}
 
-	// Verify age column has ore index.
-	ageCol, ok := users["age"].(map[string]interface{})
+	ageCol, ok := users["age"].(map[string]any)
 	if !ok {
 		t.Fatal("age column: not a map")
 	}
@@ -646,7 +704,7 @@ func TestBuildEncryptConfigJSONOutput(t *testing.T) {
 		t.Errorf("age cast_as: got %v, want %q", ageCol["cast_as"], "number")
 	}
 
-	ageIndexes, ok := ageCol["indexes"].(map[string]interface{})
+	ageIndexes, ok := ageCol["indexes"].(map[string]any)
 	if !ok {
 		t.Fatal("age indexes: not a map")
 	}
@@ -660,15 +718,17 @@ func TestBuildEncryptConfigJSONOutput(t *testing.T) {
 func TestBuildEncryptConfigIntegration(t *testing.T) {
 	t.Parallel()
 
-	td := TableSchema("users", schemaTestUser{})
-	config := BuildEncryptConfig(td)
+	td, err := TableSchema("users", schemaTestUser{})
+	if err != nil {
+		t.Fatalf("TableSchema: %v", err)
+	}
+	config := buildEncryptConfigFromSchemas([]*TableDef{td})
 
 	data, err := json.Marshal(config)
 	if err != nil {
 		t.Fatalf("json.Marshal: %v", err)
 	}
 
-	// Unmarshal back into EncryptConfig to verify round-trip.
 	var roundTripped EncryptConfig
 	if err := json.Unmarshal(data, &roundTripped); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
@@ -686,7 +746,6 @@ func TestBuildEncryptConfigIntegration(t *testing.T) {
 		t.Fatalf("user columns: got %d, want 5", len(usersTable))
 	}
 
-	// Verify match index on email survived round-trip.
 	email := usersTable["email"]
 	if email.Indexes == nil || email.Indexes.MatchIndex == nil {
 		t.Fatal("email match index lost in round-trip")
@@ -709,7 +768,6 @@ func TestAnalyzeStructWithExtendedTags(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// analyzeStruct should extract just the column name from the extended tag.
 	if len(info.EncryptedFields) != 5 {
 		t.Fatalf("encrypted fields: got %d, want 5", len(info.EncryptedFields))
 	}
@@ -761,6 +819,132 @@ func TestSplitTagParts(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// --- Programmatic SchemaBuilder tests ---
+
+func TestSchemaBuilderBasic(t *testing.T) {
+	t.Parallel()
+
+	td := NewSchema("users").
+		Column("email", CastAsString).Equality(TokenFilter{Kind: "downcase"}).FreeTextSearch().Done().
+		Column("name", CastAsString).FreeTextSearch().Done().
+		Column("age", CastAsNumber).OrderAndRange().Done().
+		Build()
+
+	if td.Name() != "users" {
+		t.Errorf("name: got %q, want %q", td.Name(), "users")
+	}
+	if len(td.columns) != 3 {
+		t.Fatalf("columns: got %d, want 3", len(td.columns))
+	}
+
+	// Verify email
+	email := td.columns["email"]
+	if *email.CastAs != CastAsString {
+		t.Errorf("email cast_as: got %q, want %q", *email.CastAs, CastAsString)
+	}
+	if email.Indexes == nil || email.Indexes.UniqueIndex == nil {
+		t.Fatal("email: expected unique index")
+	}
+	if len(email.Indexes.UniqueIndex.TokenFilters) != 1 || email.Indexes.UniqueIndex.TokenFilters[0].Kind != "downcase" {
+		t.Errorf("email unique token filters: %v", email.Indexes.UniqueIndex.TokenFilters)
+	}
+	if email.Indexes.MatchIndex == nil {
+		t.Error("email: expected match index")
+	}
+
+	// Verify age
+	age := td.columns["age"]
+	if *age.CastAs != CastAsNumber {
+		t.Errorf("age cast_as: got %q, want %q", *age.CastAs, CastAsNumber)
+	}
+	if age.Indexes == nil || age.Indexes.OreIndex == nil {
+		t.Error("age: expected ore index")
+	}
+}
+
+func TestSchemaBuilderSearchableJSON(t *testing.T) {
+	t.Parallel()
+
+	td := NewSchema("data").
+		Column("metadata", CastAsString).SearchableJSON("data/metadata").Done().
+		Build()
+
+	meta := td.columns["metadata"]
+	if *meta.CastAs != CastAsJson {
+		t.Errorf("cast_as: got %q, want %q", *meta.CastAs, CastAsJson)
+	}
+	if meta.Indexes == nil || meta.Indexes.SteVecIndex == nil {
+		t.Fatal("expected ste_vec index")
+	}
+	if meta.Indexes.SteVecIndex.Prefix != "data/metadata" {
+		t.Errorf("prefix: got %q, want %q", meta.Indexes.SteVecIndex.Prefix, "data/metadata")
+	}
+}
+
+func TestSchemaBuilderFreeTextSearchWithOptions(t *testing.T) {
+	t.Parallel()
+
+	td := NewSchema("users").
+		Column("bio", CastAsText).FreeTextSearch(WithK(8), WithM(4096), WithTokenizer("standard")).Done().
+		Build()
+
+	bio := td.columns["bio"]
+	if bio.Indexes == nil || bio.Indexes.MatchIndex == nil {
+		t.Fatal("expected match index")
+	}
+	mi := bio.Indexes.MatchIndex
+	if *mi.K != 8 {
+		t.Errorf("k: got %d, want 8", *mi.K)
+	}
+	if *mi.M != 4096 {
+		t.Errorf("m: got %d, want 4096", *mi.M)
+	}
+	if mi.Tokenizer == nil || mi.Tokenizer.Kind != "standard" {
+		t.Errorf("tokenizer: got %v, want standard", mi.Tokenizer)
+	}
+}
+
+func TestSchemaBuilderColumnRef(t *testing.T) {
+	t.Parallel()
+
+	td := NewSchema("orders").
+		Column("total", CastAsNumber).OrderAndRange().Done().
+		Build()
+
+	col := td.Column("total")
+	if col.table != "orders" || col.column != "total" {
+		t.Errorf("ColumnRef: got table=%q column=%q", col.table, col.column)
+	}
+}
+
+func TestSchemaBuilderMatchDefaults(t *testing.T) {
+	t.Parallel()
+
+	td := NewSchema("t").
+		Column("c", CastAsString).FreeTextSearch().Done().
+		Build()
+
+	mi := td.columns["c"].Indexes.MatchIndex
+	if mi == nil {
+		t.Fatal("expected match index")
+	}
+	if mi.Tokenizer == nil || mi.Tokenizer.Kind != "ngram" {
+		t.Errorf("tokenizer: got %v, want ngram", mi.Tokenizer)
+	}
+	if mi.Tokenizer.TokenLength == nil || *mi.Tokenizer.TokenLength != 3 {
+		t.Errorf("token_length: got %v, want 3", mi.Tokenizer.TokenLength)
+	}
+	if *mi.K != 6 {
+		t.Errorf("k: got %d, want 6", *mi.K)
+	}
+	if *mi.M != 2048 {
+		t.Errorf("m: got %d, want 2048", *mi.M)
+	}
+	if *mi.IncludeOriginal != true {
+		t.Errorf("include_original: got %v, want true", *mi.IncludeOriginal)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Rust FFI upgrade**: `cipherstash-client` 0.24.0 -> 0.34.1-alpha.2 with `AutoStrategy`, `ZeroKMSBuilder`, unified `EqlCiphertext` format, and `GoPlaintext` multi-type support
- **Query encryption**: `EncryptQuery` / `EncryptQueryBulk` for searching encrypted columns (equality, full-text, range, JSON containment)
- **Model interface**: `EncryptModel` / `DecryptModel` / `BulkEncryptModels` / `BulkDecryptModels` using `cs` struct tags for automatic field-level encryption
- **Multi-tenant keysets**: `KeysetConfig` on `ClientOpts` for per-tenant cryptographic isolation
- **Multi-type plaintext**: Encrypt strings, numbers, booleans, and JSON (was string-only)
- **Structured errors**: `EncryptionError` with `ErrorCode` for programmatic error handling
- **`IsEncrypted` validation**: Standalone function to check if a value is encrypted
- **Renamed**: "CipherStash Go Encryption SDK" (was "Protect.go")

## Breaking changes

- `Encrypted` struct: removed `Kind` field, unified format
- `Plaintext` fields: `string` -> `interface{}`
- `Decrypt` return: `string` -> `interface{}`
- `DecryptOptions.Ciphertext`: `string` -> `*Encrypted`
- `BulkDecryptPayload.Ciphertext`: `string` -> `*Encrypted`
- `CastAs` constants: renamed (`big_int` -> `bigint`, `real`/`double` -> `number`, `jsonb` -> `json`, added `string`)
- Errors: `errors.New` -> `*EncryptionError` with error codes

## Test plan

- [x] Rust: 71 tests passing (query ops, index lookup, type inference, lock context grouping, is_encrypted, encrypt config validation)
- [x] Go: 48 tests passing (30 protect + 18 model — struct tag parsing, type coercion, error codes, JSON serialization)
- [ ] CI: precompiled libraries need rebuilding for all 6 platforms (this PR triggers the build workflow)
- [ ] Integration test with real CipherStash credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)